### PR TITLE
fix: return SQLitePlatform in ForbiddenDriver to allow metadata initi…

### DIFF
--- a/src/Doctrine/ForbiddenDriver.php
+++ b/src/Doctrine/ForbiddenDriver.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\ServerVersionProvider;
 use LogicException;
 use SensitiveParameter;
@@ -22,9 +23,8 @@ final class ForbiddenDriver implements Driver
 
     private const ERROR_MESSAGE =
         'Attempted to use the default (dummy) Doctrine connection. ' .
-        'You MUST explicitly use a named connection or entity manager: ' .
-        'invoices_uk, insurance_uk, billing_uk, etc. ' .
-        'See config/packages/doctrine.yaml for details.';
+        'You MUST explicitly use a named entity manager: em(\'name\') or --em=name. ' .
+        'See config/packages/doctrine.yaml for configured connections.';
 
 
     public function connect( #[SensitiveParameter] array $params ): DriverConnection
@@ -34,7 +34,10 @@ final class ForbiddenDriver implements Driver
 
     public function getDatabasePlatform( ServerVersionProvider $versionProvider ): AbstractPlatform
     {
-        throw new LogicException( self::ERROR_MESSAGE );
+        // Must return a valid platform so Doctrine ORM can initialize entity metadata
+        // and generate proxy classes without connecting. Actual connections still
+        // throw via connect().
+        return new SQLitePlatform();
     }
 
     public function getExceptionConverter(): ExceptionConverter


### PR DESCRIPTION
This pull request updates the `ForbiddenDriver` in `src/Doctrine/ForbiddenDriver.php` to improve error messaging and compatibility with Doctrine ORM initialization. The main changes clarify usage instructions and ensure that Doctrine can initialize without an active database connection.

**Error messaging improvements:**

* Updated the `ERROR_MESSAGE` constant to clarify that a named entity manager (using `em('name')` or `--em=name`) must be used, and pointed to the correct configuration file for connection details.

**Doctrine ORM compatibility:**

* Modified `getDatabasePlatform()` to return a valid `SQLitePlatform` instead of throwing an exception, allowing Doctrine ORM to initialize entity metadata and generate proxy classes without requiring a database connection. [[1]](diffhunk://#diff-f3318a01f2f6d9e85eed37190a17df63af33cf1f6c8b3d996c014d40b3e355a3L37-R40) [[2]](diffhunk://#diff-f3318a01f2f6d9e85eed37190a17df63af33cf1f6c8b3d996c014d40b3e355a3R9)…alization