### PR TITLE
Templates cache

### DIFF
--- a/app/Http/Controller/Defaults/SettingsController.php
+++ b/app/Http/Controller/Defaults/SettingsController.php
@@ -47,7 +47,7 @@ final class SettingsController extends AbstractController
     }
 
 
-    #[Route( url: 'settings/change_language/{$lang}', httpMethod: 'GET' )]
+    #[Route( url: 'settings/change_language/{lang}', httpMethod: 'GET' )]
     public function change_language_get_handler( string $lang ): RedirectResponse
     {
         Lang::setCurrentLocale( $lang );

--- a/src/Classes/Abstracts/AbstractView.php
+++ b/src/Classes/Abstracts/AbstractView.php
@@ -44,7 +44,7 @@ abstract class AbstractView
         if ( TEMPLATES_CACHE_ENABLED ) {
             $result = TemplatesCache::getInstance()->getCachedTemplateClass( $view );
             if ( $result !== false ) {
-                if ( class_exists( $result['className'] ) === false )
+                if ( class_exists( $result['className'], false ) === false )
                     eval( $result['fileContent'] );
                 $view = $result['className'];
             }

--- a/src/Classes/Abstracts/AbstractView.php
+++ b/src/Classes/Abstracts/AbstractView.php
@@ -44,7 +44,8 @@ abstract class AbstractView
         if ( TEMPLATES_CACHE_ENABLED ) {
             $result = TemplatesCache::getInstance()->getCachedTemplateClass( $view );
             if ( $result !== false ) {
-                eval( $result['fileContent'] );
+                if ( class_exists( $result['className'] ) === false )
+                    eval( $result['fileContent'] );
                 $view = $result['className'];
             }
         }

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -36,7 +36,8 @@ final class Response extends \Symfony\Component\HttpFoundation\Response
             if ( TEMPLATES_CACHE_ENABLED ) {
                 $result = TemplatesCache::getInstance()->getCachedTemplateClass( Kernel::getHeaderTemplateClassName() );
                 if ( $result !== false ) {
-                    eval( $result['fileContent'] );
+                    if ( class_exists( $result['className'] ) === false )
+                        eval( $result['fileContent'] );
                     $headerClassName = $result['className'];
                 }
             }
@@ -62,7 +63,8 @@ final class Response extends \Symfony\Component\HttpFoundation\Response
             if ( TEMPLATES_CACHE_ENABLED ) {
                 $result = TemplatesCache::getInstance()->getCachedTemplateClass( Kernel::getFooterTemplateClassName() );
                 if ( $result !== false ) {
-                    eval( $result['fileContent'] );
+                    if ( class_exists( $result['className'] ) === false )
+                        eval( $result['fileContent'] );
                     $footerClassName = $result['className'];
                 }
             }

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -7,6 +7,7 @@ use JetBrains\PhpStorm\NoReturn;
 use PHP_SF\System\Classes\Abstracts\AbstractView;
 use PHP_SF\System\Kernel;
 use PHP_SF\System\Router;
+
 use function function_exists;
 
 final class Response extends \Symfony\Component\HttpFoundation\Response
@@ -36,7 +37,7 @@ final class Response extends \Symfony\Component\HttpFoundation\Response
             if ( TEMPLATES_CACHE_ENABLED ) {
                 $result = TemplatesCache::getInstance()->getCachedTemplateClass( Kernel::getHeaderTemplateClassName() );
                 if ( $result !== false ) {
-                    if ( class_exists( $result['className'] ) === false )
+                    if ( class_exists( $result['className'], false ) === false )
                         eval( $result['fileContent'] );
                     $headerClassName = $result['className'];
                 }
@@ -63,7 +64,7 @@ final class Response extends \Symfony\Component\HttpFoundation\Response
             if ( TEMPLATES_CACHE_ENABLED ) {
                 $result = TemplatesCache::getInstance()->getCachedTemplateClass( Kernel::getFooterTemplateClassName() );
                 if ( $result !== false ) {
-                    if ( class_exists( $result['className'] ) === false )
+                    if ( class_exists( $result['className'], false ) === false )
                         eval( $result['fileContent'] );
                     $footerClassName = $result['className'];
                 }

--- a/src/Core/TemplatesCache.php
+++ b/src/Core/TemplatesCache.php
@@ -134,12 +134,12 @@ final class TemplatesCache
     #[ArrayShape( ['className' => 'string', 'fileContent' => 'string'] )]
     public function getCachedTemplateClass( string $className ): array|false
     {
-        if ( TEMPLATES_CACHE_ENABLED === false || strpos( $className, self::TEMPLATES_NAMESPACE ) )
+        if ( TEMPLATES_CACHE_ENABLED === false || str_contains( $className, self::TEMPLATES_NAMESPACE ) )
             return false;
 
         $cacheKey = sprintf( 'cached_template_class_%s', $className );
 
-        if ( ca()->has( $cacheKey ) )
+        if ( DEV_MODE === false && ca()->has( $cacheKey ) )
             return j_decode( ca()->get( $cacheKey ), true );
 
 
@@ -189,8 +189,8 @@ final class TemplatesCache
 
         //remove redundant characters
         $replace = [
-            // Remove JS inline comments
-            '/\/\/.*$/m' => '',
+            // Remove JS inline comments (negative lookbehind skips URLs like http://)
+            '/(?<!:)\/\/.*$/m' => '',
             //remove HTML comments
             '/<!--(.|\s)*?-->/' => '',
             //remove HTML comments
@@ -216,7 +216,7 @@ final class TemplatesCache
             '/\),[\r\n\t ]+/s' => '),',
             //remove quotes from HTML attributes that does not contain spaces; keep quotes around URLs!
             //$1 and $4 insert first white-space character found before/after attribute
-            '~([\r\n\t ])?([a-zA-Z0-9]+)="([a-zA-Z0-9_/\\-]+)"([\r\n\t ])?~s' => '$1$2=$3$4',
+            '~([\r\n\t ])?([a-zA-Z0-9]+)="([a-zA-Z0-9_/\\-]+)"(?=[\r\n\t >])~s' => '$1$2=$3',
             '/<!--.*?-->/' => '',
             '/(\x20+|\t)/' => ' ', # Delete multispace (Without \n)
             '/(["\'])\s+>/' => "$1>", # strip whitespaces between quotation ("') and end tags
@@ -262,16 +262,14 @@ final class TemplatesCache
         $remove = [ '</option>', '</li>', '</dt>', '</dd>', '</tr>', '</th>', '</td>', ];
         $fileContent = trim( str_ireplace( $remove, '', $fileContent ) );
 
-        if ( DEV_MODE === true || ca()->has( $cacheKey ) === false ) {
-            $result = [
-                'className' => $newClassName,
-                'fileContent' => substr( $fileContent, 5 ),
-            ];
+        $result = [
+            'className' => $newClassName,
+            'fileContent' => substr( $fileContent, 5 ),
+        ];
 
-            ca()->set( $cacheKey, j_encode( $result ) );
-        }
+        ca()->set( $cacheKey, j_encode( $result ) );
 
-        return j_decode( ca()->get( $cacheKey ), true );
+        return $result;
     }
 
     /**

--- a/src/Core/TemplatesCache.php
+++ b/src/Core/TemplatesCache.php
@@ -134,7 +134,11 @@ final class TemplatesCache
     #[ArrayShape( ['className' => 'string', 'fileContent' => 'string'] )]
     public function getCachedTemplateClass( string $className ): array|false
     {
-        if ( TEMPLATES_CACHE_ENABLED === false || str_contains( $className, self::TEMPLATES_NAMESPACE ) )
+        if (
+            TEMPLATES_CACHE_ENABLED === false
+            || str_starts_with( $className, self::TEMPLATES_NAMESPACE . '\\' )
+            || $className === self::TEMPLATES_NAMESPACE
+        )
             return false;
 
         $cacheKey = sprintf( 'cached_template_class_%s', $className );


### PR DESCRIPTION
This pull request focuses on improving the template caching mechanism and fixing a minor route definition issue. The main changes enhance the reliability and efficiency of the template cache, especially in development mode, and improve template class handling. Below are the most important changes:

**Template Caching Improvements:**

* Added a check to only fetch cached template classes from cache when not in development mode, ensuring fresh templates are used during development (`src/Core/TemplatesCache.php`).
* Changed the return value of `getCachedTemplateClass` to always return the newly generated result instead of reading from cache in development mode, and simplified cache set/get logic (`src/Core/TemplatesCache.php`).
* Improved the regular expression for removing JavaScript comments to avoid stripping URLs and refined the regex for unquoting HTML attributes to be more precise (`src/Core/TemplatesCache.php`). [[1]](diffhunk://#diff-f6db0b571e805a3dfd903c2d09b88bc5c6e5394919a52b7526c3d3506edc8333L192-R193) [[2]](diffhunk://#diff-f6db0b571e805a3dfd903c2d09b88bc5c6e5394919a52b7526c3d3506edc8333L219-R219)

**Template Class Loading Reliability:**

* Added checks to `Response.php` and `AbstractView.php` to ensure template classes are only evaluated with `eval` if not already loaded, preventing redeclaration errors (`src/Core/Response.php`, `src/Classes/Abstracts/AbstractView.php`). [[1]](diffhunk://#diff-51fd6bc4814e53fd9c7b43c7cff357d79a05e8e0ed9b308dab430ca22e1eb527R39) [[2]](diffhunk://#diff-51fd6bc4814e53fd9c7b43c7cff357d79a05e8e0ed9b308dab430ca22e1eb527R66) [[3]](diffhunk://#diff-e1686f6c09b58a0f14ad9e3434d449154e90c9db4c020316ed17d225f744bff4R47)

**Routing Fix:**

* Fixed a typo in the route definition for changing language settings by correcting the parameter syntax in `SettingsController.php`.