### PR TITLE
Symfony event listener to bridge PHP_SF controllers for functional testing

### DIFF
--- a/app/EventListener/PhpSfControllerListener.php
+++ b/app/EventListener/PhpSfControllerListener.php
@@ -3,10 +3,13 @@
 namespace PHP_SF\Framework\EventListener;
 
 use PHP_SF\System\Classes\Abstracts\AbstractController;
+use PHP_SF\System\Core\RedirectResponse as PhpSfRedirectResponse;
 use PHP_SF\System\Core\Response as PhpSfResponse;
 use PHP_SF\System\Router;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -18,18 +21,43 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *   1. Properly instantiate PHP_SF controllers with the current Symfony Request.
  *   2. Capture their rendered output into the Response's content property so
  *      KernelBrowser can read it via getContent().
+ *   3. Convert PHP_SF's in-process RedirectResponse into a proper HTTP 302 so that
+ *      Codeception's followRedirect() works, and carry flash data to the next request.
+ *
+ * Flash data (errors/messages/form_data) is carried via a static in-process bag.
+ * Codeception runs all requests in the same PHP process via KernelBrowser, so a
+ * static property is the simplest reliable mechanism — no session complexity needed.
  *
  * Registered only in the test environment via config/services.yaml "when@test".
  */
 final class PhpSfControllerListener implements EventSubscriberInterface
 {
 
+    /** Flash bag: populated on redirect response, consumed on the next request. */
+    private static array $flashBag = [];
+
     public static function getSubscribedEvents(): array
     {
         return [
+            KernelEvents::REQUEST    => [ 'onKernelRequest', 10 ],
             KernelEvents::CONTROLLER => [ 'onKernelController', 10 ],
             KernelEvents::RESPONSE   => [ 'onKernelResponse', 10 ],
         ];
+    }
+
+    /**
+     * On every main request: consume the static flash bag and populate the globals
+     * that PHP_SF templates read via getErrors(), getMessages(), formValue().
+     */
+    public function onKernelRequest( RequestEvent $event ): void
+    {
+        if ( !$event->isMainRequest() )
+            return;
+
+        $GLOBALS['errors']    = self::$flashBag['errors']   ?? [];
+        $GLOBALS['messages']  = self::$flashBag['messages'] ?? [];
+        $GLOBALS['form_data'] = self::$flashBag['formData'] ?? [];
+        self::$flashBag = [];
     }
 
     public function onKernelController( ControllerEvent $event ): void
@@ -52,20 +80,46 @@ final class PhpSfControllerListener implements EventSubscriberInterface
         $request  = $event->getRequest();
         $routeUrl = $request->attributes->get( '_php_sf_url', '' );
 
-        // Set Router::$currentRoute so Response::send() / captureContent() can
-        // check the URL (e.g. to skip header/footer for /api/ routes).
-        Router::$currentRoute = (object) [ 'url' => $routeUrl ];
+        // Reconstruct the currentRoute object that templates and Response::send() rely on.
+        // Normally set by Router::setCurrentRoute(); in tests we rebuild it from request attributes.
+        [ $ctrlClass, $ctrlMethod ] = explode( '::', $request->attributes->get( '_controller', '::' ), 2 );
+        Router::$currentRoute = (object) [
+            'url'        => $routeUrl,
+            'name'       => $request->attributes->get( '_route', '' ),
+            'class'      => $ctrlClass,
+            'method'     => $ctrlMethod,
+            'httpMethod' => $request->getMethod(),
+            'middleware' => $request->attributes->get( '_php_sf_middleware', [] ),
+        ];
 
         // Replace the callable: ControllerResolver would do `new $class()` (no request),
         // here we inject the Symfony Request and forward route params correctly.
         $event->setController( static function () use ( $class, $method, $request ): mixed {
             $instance = new $class( $request );
 
-            $params = [];
+            $rawParams = [];
             foreach ( $request->attributes->all() as $key => $value ) {
                 if ( str_starts_with( $key, '_' ) )
                     continue;
-                $params[ $key ] = $value;
+                $rawParams[ $key ] = $value;
+            }
+
+            if ( empty( $rawParams ) )
+                return $instance->$method();
+
+            // Cast each param to the type declared in the method signature,
+            // mirroring what Router::setRouteParameters() does in production.
+            $reflection = new \ReflectionMethod( $class, $method );
+            $params     = [];
+            foreach ( $reflection->getParameters() as $rp ) {
+                $name = $rp->getName();
+                if ( !array_key_exists( $name, $rawParams ) )
+                    continue;
+                $value = $rawParams[ $name ];
+                $type  = $rp->getType()?->getName();
+                if ( $type !== null )
+                    settype( $value, $type );
+                $params[] = $value;
             }
 
             return $instance->$method( ...$params );
@@ -76,11 +130,39 @@ final class PhpSfControllerListener implements EventSubscriberInterface
     {
         $response = $event->getResponse();
 
-        if ( !( $response instanceof PhpSfResponse ) )
-            return;
+        // ── PHP_SF RedirectResponse ───────────────────────────────────────────
+        // Production: RedirectResponse::send() re-dispatches via Router::init() (exit-based).
+        // Tests: convert to proper HTTP 302, carry flash data via the static bag.
+        if ( $response instanceof PhpSfRedirectResponse ) {
+            $targetUrl     = $response->getTargetUrl();
+            $requestDataId = $response->getRequestDataId();
 
-        $routeUrl = $event->getRequest()->attributes->get( '_php_sf_url', '/' );
-        $response->captureContent( $routeUrl );
+            if ( $requestDataId !== null ) {
+                $urlKey   = hash( 'xxh3', $targetUrl );
+                $cacheKey = "$urlKey:$requestDataId";
+
+                $rawErrors   = ca()->get( ":ERRORS:$cacheKey" );
+                $rawMessages = ca()->get( ":MESSAGES:$cacheKey" );
+                $rawFormData = ca()->get( ":FORM_DATA:$cacheKey" );
+
+                self::$flashBag = [
+                    'errors'   => $rawErrors   !== null ? j_decode( $rawErrors,   true ) : [],
+                    'messages' => $rawMessages !== null ? j_decode( $rawMessages, true ) : [],
+                    'formData' => $rawFormData !== null ? j_decode( $rawFormData, true ) : [],
+                ];
+            }
+
+            $event->setResponse( new SymfonyRedirectResponse( $targetUrl ) );
+            return;
+        }
+
+        // ── PHP_SF Response ───────────────────────────────────────────────────
+        // Render the page (header + view + footer) into $response->content so that
+        // KernelBrowser can read it via getContent().
+        if ( $response instanceof PhpSfResponse ) {
+            $routeUrl = $event->getRequest()->attributes->get( '_php_sf_url', '/' );
+            $response->captureContent( $routeUrl );
+        }
     }
 
 }

--- a/app/EventListener/PhpSfControllerListener.php
+++ b/app/EventListener/PhpSfControllerListener.php
@@ -1,0 +1,86 @@
+<?php declare( strict_types=1 );
+
+namespace PHP_SF\Framework\EventListener;
+
+use PHP_SF\System\Classes\Abstracts\AbstractController;
+use PHP_SF\System\Core\Response as PhpSfResponse;
+use PHP_SF\System\Router;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Bridges PHP_SF framework controllers into Symfony's HttpKernel for functional tests.
+ *
+ * In production, Router::init() handles PHP_SF controller dispatch entirely (and exits).
+ * In tests, Symfony's KernelBrowser drives the request cycle, so we need to:
+ *   1. Properly instantiate PHP_SF controllers with the current Symfony Request.
+ *   2. Capture their rendered output into the Response's content property so
+ *      KernelBrowser can read it via getContent().
+ *
+ * Registered only in the test environment via config/services.yaml "when@test".
+ */
+final class PhpSfControllerListener implements EventSubscriberInterface
+{
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER => [ 'onKernelController', 10 ],
+            KernelEvents::RESPONSE   => [ 'onKernelResponse', 10 ],
+        ];
+    }
+
+    public function onKernelController( ControllerEvent $event ): void
+    {
+        $controller = $event->getController();
+
+        // PhpSfRouteLoader registers controllers as 'ClassName::method' strings.
+        if ( is_string( $controller ) && str_contains( $controller, '::' ) )
+            $controller = explode( '::', $controller, 2 );
+
+        if ( !is_array( $controller ) || count( $controller ) !== 2 )
+            return;
+
+        [ $classOrInstance, $method ] = $controller;
+        $class = is_object( $classOrInstance ) ? $classOrInstance::class : $classOrInstance;
+
+        if ( !is_a( $class, AbstractController::class, true ) )
+            return;
+
+        $request  = $event->getRequest();
+        $routeUrl = $request->attributes->get( '_php_sf_url', '' );
+
+        // Set Router::$currentRoute so Response::send() / captureContent() can
+        // check the URL (e.g. to skip header/footer for /api/ routes).
+        Router::$currentRoute = (object) [ 'url' => $routeUrl ];
+
+        // Replace the callable: ControllerResolver would do `new $class()` (no request),
+        // here we inject the Symfony Request and forward route params correctly.
+        $event->setController( static function () use ( $class, $method, $request ): mixed {
+            $instance = new $class( $request );
+
+            $params = [];
+            foreach ( $request->attributes->all() as $key => $value ) {
+                if ( str_starts_with( $key, '_' ) )
+                    continue;
+                $params[ $key ] = $value;
+            }
+
+            return $instance->$method( ...$params );
+        } );
+    }
+
+    public function onKernelResponse( ResponseEvent $event ): void
+    {
+        $response = $event->getResponse();
+
+        if ( !( $response instanceof PhpSfResponse ) )
+            return;
+
+        $routeUrl = $event->getRequest()->attributes->get( '_php_sf_url', '/' );
+        $response->captureContent( $routeUrl );
+    }
+
+}

--- a/app/Routing/PhpSfRouteLoader.php
+++ b/app/Routing/PhpSfRouteLoader.php
@@ -44,7 +44,11 @@ final class PhpSfRouteLoader extends Loader
                 $routeName,
                 ( new Route( $route['url'] ) )
                     ->setMethods( [ $route['httpMethod'] ] )
-                    ->addDefaults( [ '_controller' => $route['class'] . '::' . $route['method'] ] )
+                    ->addDefaults( [
+                        '_controller'        => $route['class'] . '::' . $route['method'],
+                        '_php_sf_url'        => $route['url'],
+                        '_php_sf_middleware' => $route['middleware'] ?? [],
+                    ] )
             );
         }
 

--- a/src/Classes/Abstracts/AbstractController.php
+++ b/src/Classes/Abstracts/AbstractController.php
@@ -20,7 +20,7 @@ abstract class AbstractController
     private string $generatedUrl;
 
 
-    public function __construct( protected Request|null $request ) {}
+    public function __construct( protected Request|null $request = null ) {}
 
 
     final protected function render( string $view, array $data = [], string $pageTitle = null ): Response

--- a/src/Core/RedirectResponse.php
+++ b/src/Core/RedirectResponse.php
@@ -33,7 +33,7 @@ final class RedirectResponse extends Response
 
     public function __construct(
         #[Immutable] private readonly string $targetUrl,
-        #[Immutable] private readonly float|null $requestDataId = null
+        #[Immutable] private readonly string|null $requestDataId = null
     ) {
         parent::__construct();
     }
@@ -109,7 +109,7 @@ final class RedirectResponse extends Response
         return $this->targetUrl;
     }
 
-    public function getRequestDataId(): float|null
+    public function getRequestDataId(): string|null
     {
         return $this->requestDataId;
     }

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -27,6 +27,33 @@ final class Response extends \Symfony\Component\HttpFoundation\Response
     }
 
     /**
+     * Renders the full page (header + view + footer) into a string and stores it
+     * via {@see setContent()} so that Symfony's KernelBrowser can read it in tests.
+     * Unlike {@see send()}, this method does NOT flush the output buffer or call exit().
+     */
+    public function captureContent( string $routeUrl ): void
+    {
+        ob_start();
+
+        $isApi = str_starts_with( $routeUrl, '/api/' );
+
+        if ( !$isApi )
+            ( new ( Kernel::getHeaderTemplateClassName() )( $this->dataFromController ) )->show();
+
+        if ( $this->view instanceof AbstractView ) {
+            $array = explode( '\\', $this->view::class );
+            echo '<div class="' . array_pop( $array ) . '">';
+            $this->view->show();
+            echo '</div>';
+        }
+
+        if ( !$isApi )
+            ( new ( Kernel::getFooterTemplateClassName() )( $this->dataFromController ) )->show();
+
+        $this->setContent( (string) ob_get_clean() );
+    }
+
+    /**
      * @noinspection PhpMissingParentCallCommonInspection
      * @noinspection OffsetOperationsInspection
      * @noinspection MissingParentCallInspection

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -35,22 +35,27 @@ final class Response extends \Symfony\Component\HttpFoundation\Response
     {
         ob_start();
 
-        $isApi = str_starts_with( $routeUrl, '/api/' );
+        try {
+            $isApi = str_starts_with( $routeUrl, '/api/' );
 
-        if ( !$isApi )
-            ( new ( Kernel::getHeaderTemplateClassName() )( $this->dataFromController ) )->show();
+            if ( !$isApi )
+                ( new ( Kernel::getHeaderTemplateClassName() )( $this->dataFromController ) )->show();
 
-        if ( $this->view instanceof AbstractView ) {
-            $array = explode( '\\', $this->view::class );
-            echo '<div class="' . array_pop( $array ) . '">';
-            $this->view->show();
-            echo '</div>';
+            if ( $this->view instanceof AbstractView ) {
+                $array = explode( '\\', $this->view::class );
+                echo '<div class="' . array_pop( $array ) . '">';
+                $this->view->show();
+                echo '</div>';
+            }
+
+            if ( !$isApi )
+                ( new ( Kernel::getFooterTemplateClassName() )( $this->dataFromController ) )->show();
+
+            $this->setContent( (string) ob_get_clean() );
+        } catch ( \Throwable $e ) {
+            ob_end_clean();
+            throw $e;
         }
-
-        if ( !$isApi )
-            ( new ( Kernel::getFooterTemplateClassName() )( $this->dataFromController ) )->show();
-
-        $this->setContent( (string) ob_get_clean() );
     }
 
     /**

--- a/src/Traits/ModelProperty/ModelPropertyCreatedAtTrait.php
+++ b/src/Traits/ModelProperty/ModelPropertyCreatedAtTrait.php
@@ -8,12 +8,10 @@ use Doctrine\ORM\Mapping as ORM;
 use PHP_SF\System\Attributes\Validator\TranslatablePropertyName;
 use PHP_SF\System\Core\DateTime;
 use Symfony\Component\Serializer\Attribute\Groups;
-use Symfony\Component\Validator\Constraints as Assert;
 
 trait ModelPropertyCreatedAtTrait
 {
 
-    #[Assert\DateTime]
     #[TranslatablePropertyName('Created At')]
     #[ORM\Column(name: 'created_at', type: 'datetime', nullable: false, options: ['default' => new CurrentTimestamp()])]
     #[Groups(['read'])]

--- a/src/Traits/ModelProperty/ModelPropertyUpdatedAtTrait.php
+++ b/src/Traits/ModelProperty/ModelPropertyUpdatedAtTrait.php
@@ -8,12 +8,10 @@ use Doctrine\ORM\Mapping as ORM;
 use PHP_SF\System\Attributes\Validator\TranslatablePropertyName;
 use PHP_SF\System\Core\DateTime;
 use Symfony\Component\Serializer\Attribute\Groups;
-use Symfony\Component\Validator\Constraints as Assert;
 
 trait ModelPropertyUpdatedAtTrait
 {
 
-    #[Assert\DateTime]
     #[TranslatablePropertyName('Updated At')]
     #[ORM\Column(name: 'updated_at', type: 'datetime', nullable: true, options: ['default' => new CurrentTimestamp()])]
     #[Groups(['read', 'write'])]

--- a/src/Traits/RedirectTrait.php
+++ b/src/Traits/RedirectTrait.php
@@ -147,7 +147,7 @@ trait RedirectTrait
     }
 
 
-    private function generateData( string $url, array|null $get = null, array|null $post = null, array|null $errors = null, array|null $messages = null, array|null $formData = null ): float
+    private function generateData( string $url, array|null $get = null, array|null $post = null, array|null $errors = null, array|null $messages = null, array|null $formData = null ): string
     {
         $get        ??= [];
         $post       ??= [];
@@ -155,7 +155,7 @@ trait RedirectTrait
         $messages   ??= [];
         $formData   ??= [];
         $hashedUrl  = hash( 'xxh3', $url );
-        $redirectId = hrtime( true );
+        $redirectId = (string)hrtime( true );
 
         $this->validateParams( $get, $post );
         $this->validateErrors( $errors );

--- a/templates/Layout/footer.php
+++ b/templates/Layout/footer.php
@@ -38,7 +38,7 @@ final class footer extends AbstractView { public function show(): void { ?>
         </div>
       </div>
 
-      <?php if ( DEV_MODE === true ) : ?>
+      <?php if ( DEV_MODE === true && env('APP_ENV') !== 'test' ) : ?>
         <div class="row">
           <div class="col-6">
             <?php dump(Router::$currentRoute, AbstractEventsDispatcher::getDispatchedListeners()) ?>


### PR DESCRIPTION
This pull request introduces a new Symfony event listener to bridge PHP_SF controllers with Symfony's HttpKernel, enabling functional testing with Symfony's KernelBrowser. It also standardizes the handling of redirect flash data and response content capture for test environments, and removes an unnecessary validation annotation from model traits. Several internal type hints are updated from float to string for redirect IDs.

**Symfony integration for PHP_SF controllers (test environment):**

* Added `PhpSfControllerListener` to handle instantiation of PHP_SF controllers, manage flash data across redirects, and capture controller output as response content for Symfony's KernelBrowser in tests.
* Updated `PhpSfRouteLoader` to add special attributes (`_php_sf_url`, `_php_sf_middleware`) to each route, supporting the new listener's requirements.

**Redirect and response handling improvements:**

* Changed the type of redirect IDs from float to string throughout the codebase for consistency and reliability (`RedirectResponse`, `RedirectTrait`, and related methods). [[1]](diffhunk://#diff-493dfb364ac1bfb1628fc78b1815889a4b2c4923c98f6ec4955723279b88435aL36-R36) [[2]](diffhunk://#diff-493dfb364ac1bfb1628fc78b1815889a4b2c4923c98f6ec4955723279b88435aL112-R112) [[3]](diffhunk://#diff-28ac140d10147859b380f55677da3b7de39821ac89e569fa136a6fca4a4028d4L150-R158)
* Added a `captureContent` method to `Response` to render full page content into the response object without output buffering or exit, specifically for test scenarios.

**Model trait cleanup:**

* Removed the unnecessary `#[Assert\DateTime]` validation annotation from the `ModelPropertyCreatedAtTrait` and `ModelPropertyUpdatedAtTrait` traits. [[1]](diffhunk://#diff-43618d5232b157864f622b16a3fa6701e64e332e64371961f6317b8afef4b1e9L11-L16) [[2]](diffhunk://#diff-2ea169e7d6e0ea96375d63057569a507608aaa8699b3b9ca96589849622420d5L11-L16)

**Test/dev environment UI adjustment:**

* Updated the footer template to suppress debug output when running in the test environment.


## Description

<!-- What does this PR do? Why? Link to related issue if applicable: Fixes #... -->

## Type of change

- [ ] Bug fix
- [x] New feature / improvement
- [ ] Refactor (no behaviour change)
- [ ] Documentation / tooling
- [ ] Dependency update

## Testing

- [x] Existing tests pass (`bin/phpunit`)
- [ ] New test added that reproduces the bug / covers the feature (or not applicable — explain below)

