### PR TITLE
fix: initialise availableArguments before loop in Middleware

### DIFF
--- a/src/Classes/Abstracts/Middleware.php
+++ b/src/Classes/Abstracts/Middleware.php
@@ -79,6 +79,7 @@ abstract class Middleware implements EventSubscriberInterface
             try {
                 $listener->invoke( $eventListener, ...$parameters );
             } catch ( ArgumentCountError $e ) {
+                $availableArguments = [];
                 foreach ( $args as $argument )
                     $availableArguments[] = $argument::class;
 


### PR DESCRIPTION
$availableArguments was only assigned inside the foreach via [], so if ArgumentCountError was caught before any iteration the variable would be undefined, causing a PHP warning on the subsequent array_map call.

## Description

This pull request introduces a small change to the `dispatchEvent` method in `src/Classes/Abstracts/Middleware.php` to prepare for improved error handling when invoking event listeners.

- Added initialization of the `$availableArguments` array before populating it with argument class names in the `ArgumentCountError` catch block.

## Type of change

- [ ] Bug fix
- [ ] New feature / improvement
- [ ] Refactor (no behaviour change)
- [ ] Documentation / tooling
- [ ] Dependency update

## Testing

- [ ] Existing tests pass (`bin/phpunit`)
- [ ] New test added that reproduces the bug / covers the feature (or not applicable — explain below)

<!-- If skipping tests, explain why: -->

## Checklist

- [ ] `declare(strict_types=1)` in every new PHP file
- [ ] No `@author` tags, no unnecessary docblocks added
- [ ] No license headers in individual files
- [ ] All commits signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
