### PR TITLE
fix: repair readonly DTO serialization and drop deprecated Serializable

### DIFF
--- a/src/Classes/Abstracts/AbstractDataTransferObject.php
+++ b/src/Classes/Abstracts/AbstractDataTransferObject.php
@@ -2,21 +2,19 @@
 
 namespace PHP_SF\System\Classes\Abstracts;
 
-use Serializable;
-
 /**
  * Class AbstractDataTransferObject
  *
  * @package PHP_SF\System\Classes\Abstracts
  */
-abstract readonly class AbstractDataTransferObject implements Serializable
+abstract readonly class AbstractDataTransferObject
 {
 
     /**
      * Create an instance of DTO class from array
      *
      * @param array $array
-     *`
+     *
      * @return static
      */
     public static function fromArray( array $array ): static
@@ -42,21 +40,11 @@ abstract readonly class AbstractDataTransferObject implements Serializable
     /**
      * Convert the DTO to string.
      *
-     * @return object
+     * @return string
      */
     public function toString(): string
     {
         return json_encode( $this->toArray() );
-    }
-
-    public function serialize(): string
-    {
-        return serialize($this->toArray());
-    }
-
-    public function unserialize(string $data)
-    {
-        $this->fromArray(unserialize($data));
     }
 
     public function __serialize(): array
@@ -64,9 +52,10 @@ abstract readonly class AbstractDataTransferObject implements Serializable
         return $this->toArray();
     }
 
-    public function __unserialize(array $data): void
+    public function __unserialize( array $data ): void
     {
-        $this->fromArray($data);
+        foreach ( $data as $key => $value )
+            $this->$key = $value;
     }
 
 }


### PR DESCRIPTION
AbstractDataTransferObject was declared readonly but __unserialize() called fromArray() which returns a new instance, leaving $this unmodified — a silent no-op that caused data loss on deserialization.

- __unserialize() now directly assigns each key onto $this, which PHP permits for readonly classes during the unserialization protocol
- Drop the deprecated Serializable interface and its serialize()/ unserialize() methods in favour of the __serialize()/__unserialize() pair (Serializable deprecated since PHP 8.1)
- Fix toString() @return docblock (was incorrectly @return object)
- Remove stray backtick in fromArray() docblock

## Description

This pull request refactors the `AbstractDataTransferObject` class to modernize serialization logic and remove legacy interfaces. The main focus is on dropping the old `Serializable` interface and its methods in favor of PHP's magic serialization methods.

### Serialization and Interface Changes

* Removed the implementation of the `Serializable` interface and its related methods (`serialize` and `unserialize`) from `AbstractDataTransferObject`, relying instead on PHP's magic methods for serialization. [[1]](diffhunk://#diff-32189949a2b46d1bcdf0658408396f04e84b443d29ca0d42fea8fbf5961c9976L5-R17) [[2]](diffhunk://#diff-32189949a2b46d1bcdf0658408396f04e84b443d29ca0d42fea8fbf5961c9976L45-R58)
* Updated the `__unserialize` method to directly set properties from the data array, replacing the previous use of `fromArray`.

### Minor Improvements

* Fixed the return type annotation in the `toString` method's docblock to correctly indicate it returns a `string`.

## Type of change

- [x] Bug fix
- [ ] New feature / improvement
- [x] Refactor (no behaviour change)
- [ ] Documentation / tooling
- [ ] Dependency update

## Testing

- [x] Existing tests pass (`bin/phpunit`)
- [ ] New test added that reproduces the bug / covers the feature (or not applicable — explain below)

<!-- If skipping tests, explain why: -->

## Checklist

- [ ] `declare(strict_types=1)` in every new PHP file
- [ ] No `@author` tags, no unnecessary docblocks added
- [ ] No license headers in individual files
- [ ] All commits signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
