### PR TITLE
replaced custom translator with symfony/translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,13 +192,13 @@ Global helper functions cover the most common framework operations without requi
 | `rc()`                                   | Get the Redis client                            |
 | `s()`                                    | Get the current Session                         |
 | `routeLink(string $name, array $params)` | Generate a URL from a named route               |
-| `_t(string $key)`                        | Translate a string                              |
+| `_t(string $key, array $parameters = [])` | Translate a string (ICU `{param}` placeholders) |
 
 Full reference: [Helper Functions](https://wiki.nations-original.com/framework/supporting/helpers).
 
 ### Translation
 
-Translation files live in `lang/` and are loaded during kernel boot. Use `_t('key')` anywhere in templates or controllers.
+Translation files are YAML in `translations/` (app) and `Platform/translations/` (framework), using ICU `{param}` syntax. Use `_t('key')` or `_t('key', ['param' => $value])` anywhere in templates or controllers.
 
 Full reference: [Translation](https://wiki.nations-original.com/framework/supporting/translation).
 

--- a/app/Http/Controller/AuthController.php
+++ b/app/Http/Controller/AuthController.php
@@ -53,16 +53,16 @@ class AuthController extends AbstractController
 
 
         if ( empty( $email ) || empty( $password ) )
-            $errors[] = _t( 'email_and_password_cannot_be_empty' );
+            $errors[] = _t( 'auth.login_form.empty_credentials_error' );
 
         if ( ( $user = $this->userRepository->findOneBy( [ 'email' => $email ] ) ) === null )
             if ( ( $user = $this->userRepository->findOneBy( [ 'login' => $email ] ) ) === null )
-                $errors[] = _t( 'User with this email not found.' );
+                $errors[] = _t( 'auth.login_form.user_not_found_error' );
 
 
         if ( $user !== null )
             if ( password_verify( $password, $user->getPassword() ) === false )
-                $errors[] = _t( 'wrong_password' );
+                $errors[] = _t( 'auth.login_form.wrong_password_error' );
 
 
         if ( isset( $errors ) )
@@ -97,19 +97,19 @@ class AuthController extends AbstractController
         $accept   = trim( htmlspecialchars( $this->request->request->get( 'accept', '' ) ) );
 
         if ( empty( $password ) || empty( $email ) )
-            $errors[] = _t( 'email_and_password_cannot_be_empty' );
+            $errors[] = _t( 'auth.login_form.empty_credentials_error' );
 
         if ( ( $passwordLength = strlen( $password ) ) < 6 || $passwordLength > 50 )
-            $errors[] = _t( 'Field `%s` should be between `%s` and `%s`!', 'password', 6, 50 );
+            $errors[] = _t( 'auth.register_form.password_length_error', [ 'min' => 6, 'max' => 50 ] );
 
         if ( $accept !== 'on' )
-            $errors[] = _t( 'accept_checkbox_error' );
+            $errors[] = _t( 'auth.register_form.accept_terms_error' );
 
         if ( $this->userRepository->findOneBy( [ 'email' => $email ] ) !== null )
-            $errors[] = _t( 'user_email_property_with_this_value_already_exists' );
+            $errors[] = _t( 'auth.register_form.email_taken_error' );
 
         if ( $this->userRepository->findOneBy( [ 'login' => $login ] ) !== null )
-            $errors[] = _t( 'user_login_property_with_this_value_already_exists' );
+            $errors[] = _t( 'auth.register_form.login_taken_error' );
 
 
         if ( isset( $errors ) )

--- a/app/Http/Controller/Defaults/SettingsController.php
+++ b/app/Http/Controller/Defaults/SettingsController.php
@@ -27,7 +27,7 @@ final class SettingsController extends AbstractController
         $lang = $this->request->request->get( 'lang', false );
 
         if ( !$lang || !in_array( $lang, LANGUAGES_LIST, true ) )
-            return $this->redirectTo( 'change_language_page', errors: [ _t( 'something_went_wrong_try_again' ) ] );
+            return $this->redirectTo( 'change_language_page', errors: [ _t( 'common.errors.generic' ) ] );
 
         Lang::setCurrentLocale( $lang );
 

--- a/app/Http/Middleware/api_example.php
+++ b/app/Http/Middleware/api_example.php
@@ -26,7 +26,7 @@ final class api_example extends Middleware
 
 
         return new JsonResponse(
-            [ 'error' => _t( 'access_denied' ) ], JsonResponse::HTTP_FORBIDDEN
+            [ 'error' => _t( 'common.errors.access_denied' ) ], JsonResponse::HTTP_FORBIDDEN
         );
     }
 }

--- a/app/Http/Middleware/cron_example.php
+++ b/app/Http/Middleware/cron_example.php
@@ -26,7 +26,7 @@ final class cron_example extends Middleware
             return true;
 
         return new JsonResponse(
-            [ 'error' => _t( 'access_denied' ) ], JsonResponse::HTTP_FORBIDDEN
+            [ 'error' => _t( 'common.errors.access_denied' ) ], JsonResponse::HTTP_FORBIDDEN
         );
     }
 }

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -1,9 +1,9 @@
 <?php declare( strict_types=1 );
 
 use App\Kernel;
-use PHP_SF\System\Interface\UserInterface;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder;
+use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Deprecated;
 use JetBrains\PhpStorm\ExpectedValues;
 use PHP_SF\Framework\Http\Middleware\auth;
@@ -16,6 +16,7 @@ use PHP_SF\System\Core\Cache\RedisCacheAdapter;
 use PHP_SF\System\Core\Sessions;
 use PHP_SF\System\Core\Translator;
 use PHP_SF\System\Database\Redis;
+use PHP_SF\System\Interface\UserInterface;
 use PHP_SF\System\Router;
 use Predis\Client;
 use Predis\Pipeline\Pipeline;
@@ -234,15 +235,150 @@ function routeLink( string $routeName, array $pathParams = [], array $queryParam
     }
 }
 
+/**
+ * Translates a message key to the **current session locale** using Symfony's translator
+ * with the `messages+intl-icu` domain (ICU MessageFormat).
+ *
+ * **Key naming convention:** semantic dot-notation in 3–4 parts:
+ * ```
+ * <domain>.<feature>.<element>
+ * ```
+ *
+ * **Simple translation:**
+ * ```php
+ * _t( 'auth.login_form.title' )              // → 'Sign in'
+ * _t( 'common.buttons.cancel' )              // → 'Cancel'
+ * ```
+ *
+ * **Named ICU parameters** (`{param}` syntax — never positional `%s`):
+ * ```php
+ * _t( 'auth.register_form.welcome', [ 'name' => $user->getLogin() ] )
+ * // YAML: 'auth.register_form.welcome': 'Welcome, {name}!'
+ * ```
+ *
+ * **Pluralization** (`{count, plural, ...}`):
+ * ```php
+ * _t( 'notifications.unread_count', [ 'count' => 5 ] )
+ * // YAML:
+ * // notifications.unread_count: >-
+ * //   {count, plural,
+ * //     =0    {No notifications}
+ * //     one   {# notification}
+ * //     few   {# notifications}
+ * //     many  {# notifications}
+ * //     other {# notifications}
+ * //   }
+ * ```
+ *
+ * **Gender / declension** (`{field, select, ...}`):
+ * ```php
+ * _t( 'user.greeting', [ 'gender' => $user->getGender(), 'name' => $user->getName() ] )
+ * // YAML:
+ * // user.greeting: >-
+ * //   {gender, select,
+ * //     male   {Welcome, Mr. {name}}
+ * //     female {Welcome, Ms. {name}}
+ * //     other  {Welcome, {name}}
+ * //   }
+ * ```
+ *
+ * Output is wrapped in {@link nl2br()} — newlines in translations become `<br>` tags.
+ *
+ * Falls back to the raw `$key` string if no translation is found (no exception thrown).
+ *
+ * @param non-empty-string                                        $key        Translation key in dot-notation (e.g. `'auth.login_form.title'`)
+ * @param array<non-empty-string, string|int|float|\DateTimeInterface> $parameters Named ICU parameters keyed by placeholder name (e.g. `['name' => 'John', 'count' => 5]`)
+ *
+ * @return string Translated and nl2br-wrapped string
+ *
+ * @see _tt() To translate to a specific locale regardless of current session
+ * @see \PHP_SF\System\Core\Lang::getCurrentLocale()
+ * @see \PHP_SF\System\Core\Lang::setCurrentLocale()
+ */
+function _t( string $key,
+    #[ArrayShape( [
+        // Keys are dynamic — they match the {placeholder} names defined in the translation YAML.
+        // The types below cover all values accepted by PHP's IntlMessageFormatter:
 
-function _t( string $stringName, ...$values ): string
+        // --- ICU plural rule selector ({count, plural, one {...} other {...}}) ---
+        'count'  => 'int',
+
+        // --- ICU select/gender selector ({gender, select, male {...} female {...} other {...}}) ---
+        'gender' => 'string',
+
+        // --- ICU date/time formatting ({date, date, long}) ---
+        'date'   => DateTimeInterface::class,
+
+        // --- Generic named substitution ({name}, {field}, {value}, …) ---
+        'string' => 'string|int|float',
+    ] )]
+    array $parameters = []
+): string
 {
-    return nl2br( Translator::getInstance()->translate( $stringName, ...$values ) );
+    return nl2br( Translator::getInstance()->translate( $key, $parameters ) );
 }
 
-function _tt( string $stringName, string $translateTo, ...$values ): string
+/**
+ * Translates a message key to a **specific locale** using Symfony's translator
+ * with the `messages+intl-icu` domain (ICU MessageFormat).
+ *
+ * Identical to {@link _t()} in every way except the locale is explicit rather than
+ * read from the current session. Useful for generating content in the recipient's
+ * language (e.g. emails, notifications) regardless of the current user's locale.
+ *
+ * **Simple translation to a specific locale:**
+ * ```php
+ * _tt( 'common.buttons.confirm', 'pl' )      // → Polish translation
+ * _tt( 'auth.login_form.title', 'uk' )       // → Ukrainian translation
+ * ```
+ *
+ * **With named ICU parameters:**
+ * ```php
+ * _tt( 'notifications.unread_count', $recipient->getLocale(), [ 'count' => 3 ] )
+ * ```
+ *
+ * **Typical use case — email subject in recipient's language:**
+ * ```php
+ * $subject = _tt( 'mail.new_message.subject', $recipient->getLocale(), [
+ *     'sender' => $sender->getName(),
+ * ] );
+ * ```
+ *
+ * Output is wrapped in {@link nl2br()} — newlines in translations become `<br>` tags.
+ *
+ * Falls back to the raw `$key` string if no translation is found for `$locale`.
+ *
+ * @param non-empty-string                                             $key        Translation key in dot-notation (e.g. `'mail.new_message.subject'`)
+ * @param non-empty-string                                             $locale     Target locale key — must be a value present in {@link LANGUAGES_LIST} (e.g. `'en'`, `'pl'`, `'uk'`)
+ * @param array<non-empty-string, string|int|float|\DateTimeInterface> $parameters Named ICU parameters keyed by placeholder name
+ *
+ * @return string Translated and nl2br-wrapped string
+ *
+ * @see _t() To translate to the current session locale
+ * @see \PHP_SF\System\Core\Lang::getCurrentLocale()
+ * @see \PHP_SF\System\Classes\Helpers\Locale For all available locale keys
+ */
+function _tt( string $key, string $locale,
+    #[ArrayShape( [
+        // Keys are dynamic — they match the {placeholder} names defined in the translation YAML.
+        // The types below cover all values accepted by PHP's IntlMessageFormatter:
+
+        // --- ICU plural rule selector ({count, plural, one {...} other {...}}) ---
+        'count'  => 'int',
+
+        // --- ICU select/gender selector ({gender, select, male {...} female {...} other {...}}) ---
+        'gender' => 'string',
+
+        // --- ICU date/time formatting ({date, date, long}) ---
+        'date'   => DateTimeInterface::class,
+
+        // --- Generic named substitution ({name}, {field}, {value}, …) ---
+        'string' => 'string|int|float',
+    ] )]
+    array $parameters = []
+): string
 {
-    return nl2br( Translator::getInstance()->translateTo( $stringName, $translateTo, ...$values ) );
+    return nl2br( Translator::getInstance()->translateTo( $key, $locale, $parameters ) );
 }
 
 

--- a/functions/time_functions.php
+++ b/functions/time_functions.php
@@ -35,58 +35,26 @@ function getTimeDiff(DateTimeInterface|string $time, DateTimeZone $timezone = nu
 
     $interval = $d->diff(new DateTime( 'now', $timezone));
 
-    if ($interval->y !== 0) {
+    if ($interval->y !== 0)
+        $res .= _t('common.time.years',   ['count' => $interval->y]) . ' ';
 
-        if ($interval->y <= 4)
-            $res .= sprintf('%s %s ', $interval->y, _t('yr'));
+    if ($interval->m !== 0)
+        $res .= _t('common.time.months',  ['count' => $interval->m]) . ' ';
 
-        else
-            $res .= sprintf('%s %s ', $interval->y, _t('yrs'));
+    if ($interval->d !== 0 && $interval->y === 0)
+        $res .= _t('common.time.days',    ['count' => $interval->d]) . ' ';
 
-    }
+    if ($interval->h !== 0 && $interval->y === 0 && $interval->m === 0)
+        $res .= _t('common.time.hours',   ['count' => $interval->h]) . ' ';
 
-    if ($interval->m !== 0) {
-        if ($interval->m === 1)
-            $res .= sprintf('%s %s ', $interval->m, _t('mo'));
+    if ($interval->i !== 0 && $interval->m === 0 && ($interval->d === 0 || $interval->h === 0))
+        $res .= _t('common.time.minutes', ['count' => $interval->i]) . ' ';
 
-        else
-            $res .= sprintf('%s %s ', $interval->m, _t('mos'));
-    }
-
-    if (( $interval->d !== 0 ) && $interval->y === 0) {
-        if ($interval->d === 1)
-            $res .= sprintf('%s %s ', $interval->d, _t('d'));
-
-        else
-            $res .= sprintf('%s %s ', $interval->d, _t('d (plural)'));
-    }
-
-    if ($interval->h !== 0 && $interval->y === 0 && $interval->m === 0) {
-        if ($interval->h === 1)
-            $res .= sprintf('%s %s ', $interval->h, _t('hr'));
-
-        else
-            $res .= sprintf('%s %s ', $interval->h, _t('hr (plural)'));
-    }
-
-    if ($interval->i !== 0 && $interval->m === 0 && ( $interval->d === 0 || $interval->h === 0 )) {
-        if ($interval->i === 1)
-            $res .= sprintf('%s %s ', $interval->i, _t('min'));
-
-        else
-            $res .= sprintf('%s %s ', $interval->i, _t('min (plural)'));
-    }
-
-    if ($interval->s !== 0 && $interval->d === 0 && ( $interval->h === 0 || $interval->i === 0 )) {
-        if ($interval->s === 1)
-            $res .= sprintf('%s %s ', $interval->s, _t('sec'));
-
-        else
-            $res .= sprintf('%s %s ', $interval->s, _t('sec (plural)'));
-    }
+    if ($interval->s !== 0 && $interval->d === 0 && ($interval->h === 0 || $interval->i === 0))
+        $res .= _t('common.time.seconds', ['count' => $interval->s]) . ' ';
 
     if (empty($res))
-        $res = _t('moment_ago');
+        $res = _t('common.time.moment_ago');
 
     return $res;
 }

--- a/lang/en.php
+++ b/lang/en.php
@@ -1,3 +1,0 @@
-<?php /** @noinspection ALL @formatter::off */
-
-return [];

--- a/src/Classes/Abstracts/Middleware.php
+++ b/src/Classes/Abstracts/Middleware.php
@@ -39,11 +39,11 @@ abstract class Middleware implements EventSubscriberInterface
         if ( $middlewareResult === false ) {
             if ( str_starts_with( Router::$currentRoute->url, '/api/' ) )
                 $middlewareResult = new JsonResponse(
-                    [ 'error' => _t( 'access_denied' ) ], JsonResponse::HTTP_FORBIDDEN
+                    [ 'error' => _t( 'common.errors.access_denied' ) ], JsonResponse::HTTP_FORBIDDEN
                 );
 
             else
-                $middlewareResult = $this->redirectBack( errors: [ _t( 'Access Denied!' ) ] );
+                $middlewareResult = $this->redirectBack( errors: [ _t( 'common.errors.access_denied' ) ] );
 
         }
 

--- a/src/Core/Translator.php
+++ b/src/Core/Translator.php
@@ -1,9 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace PHP_SF\System\Core;
 
 use JetBrains\PhpStorm\Deprecated;
+use Symfony\Component\Translation\Formatter\IntlFormatter;
+use Symfony\Component\Translation\Formatter\MessageFormatter;
+use Symfony\Component\Translation\Loader\YamlFileLoader;
+use Symfony\Component\Translation\Translator as SymfonyTranslator;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 
@@ -17,6 +22,49 @@ final class Translator
 
     public static function setSymfonyTranslator(TranslatorInterface $translator): void
     {
+        self::$symfony = $translator;
+    }
+
+    /**
+     * Boots a lightweight standalone Symfony translator (no kernel, no DI container).
+     * Loads all *.yaml files from the provided directories for every locale subdirectory
+     * found in each path. Call this before Router::init() so PHP-SF routes have translations.
+     *
+     * The full DI-managed translator (injected by TranslatorBootSubscriber) will replace
+     * this instance for Symfony-handled routes automatically.
+     *
+     * @param string ...$translationDirs Absolute paths to directories containing YAML translation files.
+     */
+    public static function bootStandalone(string ...$translationDirs): void
+    {
+        $translator = new SymfonyTranslator(
+            Lang::getCurrentLocale(),
+            new MessageFormatter(intlFormatter: new IntlFormatter()),
+        );
+
+        $translator->addLoader('yaml', new YamlFileLoader());
+
+        foreach ($translationDirs as $dir) {
+            if ( !is_dir($dir)) {
+                continue;
+            }
+
+            foreach (glob($dir.'/*.yaml') ?: [] as $file) {
+                // Filename pattern: messages+intl-icu.en.yaml  →  locale = en
+                $basename = basename($file, '.yaml');
+                $parts    = explode('.', $basename);
+
+                if (count($parts) < 2) {
+                    continue;
+                }
+
+                $locale = array_pop($parts);
+                $domain = implode('.', $parts);
+
+                $translator->addResource('yaml', $file, $locale, $domain);
+            }
+        }
+
         self::$symfony = $translator;
     }
 

--- a/src/Core/Translator.php
+++ b/src/Core/Translator.php
@@ -1,463 +1,64 @@
-<?php declare( strict_types=1 );
+<?php
+declare(strict_types=1);
 
 namespace PHP_SF\System\Core;
 
-use AllowDynamicProperties;
-use App\Kernel;
-use PHP_SF\System\Attributes\Validator\TranslatablePropertyName;
-use PHP_SF\System\Classes\Exception\InvalidEntityConfigurationException;
-use PHP_SF\System\Classes\Helpers\Locale;
-use ReflectionClass;
-use ReflectionProperty;
-use ReflectionUnionType;
-use RuntimeException;
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-use function array_key_exists;
+use JetBrains\PhpStorm\Deprecated;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 
-/**
- * Class Translator
- *
- * Class is responsible for managing translations in the application.
- * It loads translations from specified directories, provides methods for
- * translating strings, and handles the addition of new translation strings
- * to locale files.
- *
- * @package PHP_SF\System\Core
- */
-#[AllowDynamicProperties]
 final class Translator
 {
 
-    /**
-     * An array storing all translation keys.
-     */
-    private static array $allTranslationsKeys    = [];
-    /**
-     * The singleton instance of the Translator class.
-     */
-    private static self $instance;
-    /**
-     * An array storing directories where translation files are located.
-     */
-    private static array $translationDirectories = [];
+    private const DOMAIN = 'messages+intl-icu';
+
+    private static ?TranslatorInterface $symfony = null;
 
 
-    /**
-     * Loads translations on creation.
-     */
-    private function __construct()
+    public static function setSymfonyTranslator(TranslatorInterface $translator): void
     {
-        $this->loadTranslation();
+        self::$symfony = $translator;
     }
 
 
-    /**
-     * Returns the singleton instance of the Translator class.
-     * If no instance exists, create a new one.
-     *
-     * @return self The singleton instance.
-     */
+    /** @deprecated No-op. Translation paths are now configured in config/packages/translation.yaml. */
+    #[Deprecated(
+        reason: 'No-op. Translation paths are now configured in config/packages/translation.yaml.',
+        replacement: 'No direct replacement, translation paths should be configured in config/packages/translation.yaml.'
+    )]
+    public static function addTranslationDirectory(string $translationDirectory): void
+    {
+        trigger_deprecation(
+            'php-simple-framework',
+            '1.1.9',
+            'The method %s is deprecated since version 1.1.9 and will be removed in the next major release. '.
+            'Translation paths are now configured in config/packages/translation.yaml.',
+            __METHOD__
+        );
+    }
+
+
+    public function translate(string $key, array $parameters = []): string
+    {
+        if (self::$symfony === null) {
+            return $key;
+        }
+
+        return self::$symfony->trans($key, $parameters, self::DOMAIN, Lang::getCurrentLocale());
+    }
+
+    public function translateTo(string $key, string $locale, array $parameters = []): string
+    {
+        if (self::$symfony === null) {
+            return $key;
+        }
+
+        return self::$symfony->trans($key, $parameters, self::DOMAIN, $locale);
+    }
+
     public static function getInstance(): self
     {
-        if ( isset( self::$instance ) === false )
-            return self::setInstance();
-
-
-        return self::$instance;
-    }
-
-    /**
-     * Adds a new directory to the list of translation directories.
-     *
-     * @param string $translationDirectory The directory to add.
-     */
-    public static function addTranslationDirectory( string $translationDirectory ): void
-    {
-        self::$translationDirectories[] = $translationDirectory;
-    }
-
-
-    /**
-     * Returns all translations for all supported languages.
-     *
-     * @return array<string, string<string, string>> An array of translations.
-     */
-    public function getTranslations(): array
-    {
-        foreach ( LANGUAGES_LIST as $langKey ) {
-            $translations[ $langKey ] = $this->$langKey;
-        }
-
-        return $translations;
-    }
-
-    /**
-     * Translates a given string to the current locale.
-     * If the string does not exist in the locale file, adds it.
-     *
-     * @param string $string    The string to translate.
-     * @param mixed  ...$values Values to format the translated string.
-     *
-     * @return string The translated string.
-     */
-    public function translate( string $string, ...$values ): string
-    {
-        if ( array_key_exists( $string, $this->{Lang::getCurrentLocale()} ) === false ) {
-            $this->addTranslateStringToLocaleFile( $string );
-        }
-
-        return sprintf( ( $this->{Lang::getCurrentLocale()} )[ $string ] ?? $string, ...$values );
-    }
-
-    /**
-     * Translates a given string to a specified locale.
-     * If the string does not exist in the locale file, adds it.
-     *
-     * @param string $string      The string to translate.
-     * @param string $translateTo The locale to translate to.
-     * @param mixed  ...$values   Values to format the translated string.
-     *
-     * @return string The translated string.
-     * @throws InvalidConfigurationException If the specified locale is not supported.
-     */
-    public function translateTo( string $string, string $translateTo, ...$values ): string
-    {
-        // Check if the provided locale is supported
-        if ( in_array( $translateTo, LANGUAGES_LIST, true ) === false ) {
-            throw new InvalidConfigurationException(
-                sprintf( 'Locale "%s" is not supported!', Locale::getLocaleName( $translateTo ) )
-            );
-        }
-
-        // Add the string to the locale file if it does not exist
-        if ( array_key_exists( $string, $this->$translateTo ) === false ) {
-            $this->addTranslateStringToLocaleFile( $string );
-        }
-
-        // Return the translated string or the original string if translation does not exist
-        return sprintf( ( $this->$translateTo[ $string ] ?? $string ), ...$values );
-    }
-
-
-    /**
-     * Returns the list of translation directories.
-     *
-     * @return array The list of translation directories.
-     */
-    private static function getTranslationDirectories(): array
-    {
-        return self::$translationDirectories;
-    }
-
-    /**
-     * Creates and sets the singleton instance of the Translator class.
-     *
-     * @return self The newly created instance.
-     */
-    private static function setInstance(): self
-    {
-        return self::$instance = new self;
-    }
-
-
-    /**
-     * Adds a translation string to locale files if it does not already exist.
-     * Optionally, handles recursion for nested translations.
-     *
-     * @param string $string    The string to add.
-     * @param bool   $recursion Whether to handle recursion.
-     */
-    private function addTranslateStringToLocaleFile( string $string, bool $recursion = true ): void
-    {
-        foreach ( $this as $locale => $arr )
-            $this->$locale[ $string ] = $string . ' (not_translated)';
-
-
-        $this->saveLocalesToFiles();
-
-        foreach ( $this as $locale => $arr )
-            foreach ( self::$allTranslationsKeys as $key => $value )
-                if ( !array_key_exists( $key, $this->$locale ) )
-                    $this->$locale[ $key ] = $value;
-
-
-        if ( $recursion )
-            $this->addTranslateStringToLocaleFile( $string, false );
-    }
-
-    /**
-     * Saves all locale translations to their respective files.
-     */
-    private function saveLocalesToFiles(): void
-    {
-        foreach ( self::getTranslationDirectories() as $translationDirectory ) {
-            if ( !str_contains( $translationDirectory, 'vendor/nations-original' ) ) {
-                foreach ( $this as $locale => $arr ) {
-                    ksort( $this->$locale );
-
-                    unlink( ( $path = sprintf( '%s/%s.php', $translationDirectory, $locale ) ) );
-
-                    fwrite(
-                        ( $file = fopen( $path, 'wb' ) ),
-                        '<?php /** @noinspection ALL @formatter::off */ return [' . PHP_EOL
-                    );
-
-                    $previousLetter = '';
-                    foreach ( $this->$locale as $translateString => $translation ) {
-                        if ( empty( $translateString ) )
-                            continue;
-
-
-                        self::$allTranslationsKeys[ $translateString ] = "$translateString (not_translated)";
-
-                        if ( $previousLetter !== $translateString[0] ) {
-                            fwrite( $file, '//' . PHP_EOL . '//' . PHP_EOL );
-                            $previousLetter = $translateString[0];
-                        }
-
-                        $translateString = str_replace( "'", "\'", $translateString );
-                        $translation     = str_replace( "'", "\'", $translation );
-                        if ( 13 + mb_strlen( $translateString, 'UTF-8' ) + mb_strlen( $translation, 'UTF-8' ) > 120 )
-                            fwrite( $file, "    '$translateString' " . PHP_EOL . "    => '$translation'," . PHP_EOL );
-                        else
-                            fwrite( $file, "    '$translateString' => '$translation'," . PHP_EOL );
-                    }
-
-                    fwrite( $file, '//' . PHP_EOL . '];' );
-
-                    fclose( $file );
-                }
-            }
-        }
-    }
-
-    /**
-     * Gets all translatable properties from all entities and saves them to locale files.
-     *
-     * @throws InvalidEntityConfigurationException If entity configuration is invalid.
-     * @throws RuntimeException If a directory is found deeper than one level in entity directories.
-     */
-    private function saveTranslatablePropertyNames(): void
-    {
-        $entities        = [];
-        $entityDirectory = Kernel::getInstance()->getProjectDir() . '/App/Entity';
-
-        // Get all items in entity directory
-        $items = array_diff( scandir( $entityDirectory ), [ '.', '..' ] );
-
-        foreach ( $items as $item ) {
-            $path = "$entityDirectory/$item";
-
-            if ( is_dir( $path ) ) {
-                // If the item is a directory, allow it but ensure it doesn't contain further directories
-                $subItems = array_diff( scandir( $path ), [ '.', '..' ] );
-
-                foreach ( $subItems as $subItem ) {
-                    $subPath = "$path/$subItem";
-
-                    if ( is_dir( $subPath ) ) {
-                        // Throw exception if a subdirectory is found inside a subdirectory
-                        throw new RuntimeException( 'Directories nested more than one level deep are not allowed in entity directories!' );
-                    }
-
-                    if ( is_file( $subPath ) && pathinfo( $subPath, PATHINFO_EXTENSION ) === 'php' ) {
-                        // Process PHP files inside the subdirectory
-                        $fileName  = pathinfo( $subItem, PATHINFO_FILENAME );
-                        $namespace = $this->extractNamespaceFromFile( $subPath );
-
-                        if ( $namespace === null ) {
-                            throw new InvalidEntityConfigurationException(
-                                sprintf( 'Unable to extract namespace from file "%s".', $subPath )
-                            );
-                        }
-
-                        // Add fully qualified class name to entities array
-                        $entities[] = "$namespace\\$fileName";
-                    }
-                }
-            } elseif ( is_file( $path ) && pathinfo( $path, PATHINFO_EXTENSION ) === 'php' ) {
-                // Process PHP files directly inside the entity directory
-                $fileName  = pathinfo( $item, PATHINFO_FILENAME );
-                $namespace = $this->extractNamespaceFromFile( $path );
-
-                if ( $namespace === null ) {
-                    throw new InvalidEntityConfigurationException(
-                        sprintf( 'Unable to extract namespace from file "%s".', $path )
-                    );
-                }
-
-                // Add fully qualified class name to entities array
-                $entities[] = "$namespace\\$fileName";
-            }
-            // Ignore non-PHP files
-        }
-
-        // Get all translatable properties from entities and save them to locale files
-        foreach ( $entities as $entity ) {
-            if ( !class_exists( $entity ) ) {
-                throw new InvalidEntityConfigurationException(
-                    sprintf( 'Entity class "%s" does not exist.', $entity )
-                );
-            }
-
-            $rc = new ReflectionClass( $entity );
-
-            /**
-             * Get all protected properties
-             *
-             * Because we don't want to translate private properties
-             *
-             * Private properties are used for OneToMany and ManyToOne relations
-             */
-            $properties = $rc->getProperties( ReflectionProperty::IS_PROTECTED );
-
-            foreach ( $properties as $property ) {
-                // Id property is not translatable
-                if ( $property->getName() === 'id' ) {
-                    continue;
-                }
-
-                // Boolean properties translation are optional
-                $type = $property->getType();
-                if ( $type instanceof ReflectionUnionType === false && $type?->getName() === 'bool' ) {
-                    continue;
-                }
-
-                $attributes = $property->getAttributes( TranslatablePropertyName::class );
-                $ac         = count( $attributes );
-
-                // Throw exception if attribute is missing
-                if ( $ac === 0 ) {
-                    throw new InvalidEntityConfigurationException(
-                        sprintf(
-                            'The required attribute "PHP_SF\System\Attributes\Validator\TranslatablePropertyName" is missing in the property "%s" of the entity "%s".',
-                            $property->getName(),
-                            $entity
-                        )
-                    );
-                }
-
-                // Throw exception if attribute is defined multiple times
-                if ( $ac > 1 ) {
-                    throw new InvalidEntityConfigurationException(
-                        sprintf(
-                            'The attribute "PHP_SF\System\Attributes\Validator\TranslatablePropertyName" is defined multiple times in the property "%s" of the entity "%s".',
-                            $property->getName(),
-                            $entity
-                        )
-                    );
-                }
-
-                $args = $attributes[0]->getArguments();
-
-                // Throw exception if attribute is defined without arguments
-                if ( empty( $args ) ) {
-                    throw new InvalidEntityConfigurationException(
-                        sprintf(
-                            'The attribute "PHP_SF\System\Attributes\Validator\TranslatablePropertyName" is defined without arguments in the property "%s" of the entity "%s".',
-                            $property->getName(),
-                            $entity
-                        )
-                    );
-                }
-
-                if ( array_key_exists( 'name', $args ) ) {
-                    $string = $args['name'];
-                } elseif ( array_key_exists( 0, $args ) ) {
-                    $string = $args[0];
-                } else {
-                    // Throw exception if attribute is defined without correct arguments
-                    throw new InvalidEntityConfigurationException(
-                        sprintf(
-                            'The attribute "PHP_SF\System\Attributes\Validator\TranslatablePropertyName" is defined without correct arguments in the property "%s" of the entity "%s".',
-                            $property->getName(),
-                            $entity
-                        )
-                    );
-                }
-
-                // Add string to array if it doesn't exist
-                if ( array_key_exists( $string, $this->{Lang::getCurrentLocale()} ) === false ) {
-                    $this->addTranslateStringToLocaleFile( $string );
-                }
-            }
-        }
-    }
-
-    /**
-     * Extracts the namespace from a PHP file.
-     *
-     * @param string $filePath The path to the PHP file.
-     *
-     * @return string|null The extracted namespace or null if not found.
-     */
-    private function extractNamespaceFromFile( string $filePath ): ?string
-    {
-        $contents = file_get_contents( $filePath );
-        if ( $contents === false ) {
-            return null;
-        }
-
-        // Use regex to extract namespace
-        if ( preg_match( '/namespace\s+([^;]+);/', $contents, $matches ) ) {
-            return trim( $matches[1] );
-        }
-
-        return null;
-    }
-
-    /**
-     * Loads translations from the specified directories.
-     * Throws an exception if no directories are specified.
-     *
-     * @throws InvalidConfigurationException If no translation directories are specified.
-     */
-    private function loadTranslation(): void
-    {
-        if ( empty( self::$translationDirectories ) )
-            throw new InvalidConfigurationException( 'No translation file directories specified!' );
-
-
-        foreach ( LANGUAGES_LIST as $locale ) {
-            foreach ( self::getTranslationDirectories() as $translationDirectory ) {
-                $redisKey = sprintf( 'translated_strings:%s', $locale );
-
-                if ( ( $translations = ca()->get( $redisKey ) ) === null ) {
-                    if ( file_exists( ( $path = sprintf( '%s/%s.php', $translationDirectory, $locale ) ) ) === false )
-                        // @formatter::off
-                        file_put_contents(
-                            $path,
-                            <<<'EOF'
-<?php /** @noinspection ALL @formatter::off */ return [
-/**
-* This file was automatically generated after adding new translation language to your project.
-* You can add new translated strings in format below or use {@link _t()} function.
-* "string_for_translation" => "Translation for string with arguments: %s, %s"
-* All provided strings in {@link _t()} function will be automatically added to this and another locale translation files
-*/
-];
-EOF
-                        ); // @formatter::on
-
-                    elseif ( isset( $this->$locale ) && !empty( $this->$locale ) )
-                        $this->$locale = array_merge( $this->$locale, ( require $path ) );
-
-                    else
-                        $this->$locale = require $path;
-
-
-                    if ( DEV_MODE === false )
-                        rp()->set( $redisKey, json_encode( $this->$locale ) );
-
-                } else
-                    $this->$locale = json_decode( $translations, true, 512, JSON_THROW_ON_ERROR );
-
-            }
-        }
-
-        if ( DEV_MODE )
-            $this->saveTranslatablePropertyNames();
+        return new self();
     }
 
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,10 +1,11 @@
-<?php declare( strict_types=1 );
+<?php
+declare(strict_types=1);
 
 namespace PHP_SF\System;
 
+use JetBrains\PhpStorm\Deprecated;
 use PHP_SF\System\Classes\Helpers\Locale;
 use PHP_SF\System\Core\TemplatesCache;
-use PHP_SF\System\Core\Translator;
 use PHP_SF\Templates\Layout\footer;
 use PHP_SF\Templates\Layout\header;
 use ReflectionClass;
@@ -25,45 +26,54 @@ final class Kernel
 
     public function __construct()
     {
-        require_once __DIR__ . '/../functions/functions.php';
+        require_once __DIR__.'/../functions/functions.php';
 
-        if ( DEV_MODE === true ) {
-            if ( function_exists( 'apcu_clear_cache' ) )
+        if (DEV_MODE === true) {
+            if (function_exists('apcu_clear_cache')) {
                 apcu_clear_cache();
+            }
 
-            if ( PHP_SAPI !== 'cli' )
+            if (PHP_SAPI !== 'cli') {
                 Debug::enable();
+            }
         }
 
         $this->setDefaultLocale();
 
-        $this->addControllers( __DIR__ . '/../app/Http/Controller' );
+        $this->addControllers(__DIR__.'/../app/Http/Controller');
 
-        $this->addTranslationFiles( __DIR__ . '/../lang' );
+        $this->addTemplatesDirectory('vendor/nations-original/php-simple-framework/templates', 'PHP_SF\Templates');
 
-        $this->addTemplatesDirectory( 'vendor/nations-original/php-simple-framework/templates', 'PHP_SF\Templates' );
-
-        register_shutdown_function( function () {
+        register_shutdown_function(function () {
             rp()->execute();
-        } );
+        });
     }
 
     public function addControllers(string $path): self
     {
-        if ( file_exists($path) === false )
+        if (file_exists($path) === false) {
             throw new DirectoryNotFoundException("Controllers directory '$path' not found.");
+        }
 
         Router::addControllersDirectory($path);
 
         return $this;
     }
 
+    /** @deprecated No-op. Translation paths are now configured in config/packages/translation.yaml. */
+    #[Deprecated(
+        reason: 'No-op. Translation paths are now configured in config/packages/translation.yaml.',
+        replacement: 'No direct replacement, translation paths should be configured in config/packages/translation.yaml.'
+    )]
     public function addTranslationFiles(string $path): self
     {
-        if (file_exists($path) === false)
-            throw new DirectoryNotFoundException( "Translation directory '$path' could not be found." );
-
-        Translator::addTranslationDirectory($path);
+        trigger_deprecation(
+            'php-simple-framework',
+            '1.1.9',
+            'The method %s is deprecated since version 1.1.9 and will be removed in the next major release. '.
+            'Translation paths are now configured in config/packages/translation.yaml.',
+            __METHOD__
+        );
 
         return $this;
     }
@@ -90,7 +100,7 @@ final class Kernel
     {
         if (empty(self::$applicationUserClassName)) {
             throw new InvalidConfigurationException(
-                'Application user class name not specified, you need to specify it here: ' .
+                'Application user class name not specified, you need to specify it here: '.
                 '`Kernel->setApplicationUserClassName(User::class)`'
             );
         }
@@ -100,17 +110,18 @@ final class Kernel
 
     public function setApplicationUserClassName(string $className): self
     {
-        if (class_exists($className) === false)
-            throw new InvalidConfigurationException(sprintf( "User Class '%s' does not exist", $className));
+        if (class_exists($className) === false) {
+            throw new InvalidConfigurationException(sprintf("User Class '%s' does not exist", $className));
+        }
 
         self::$applicationUserClassName = $className;
 
         return $this;
     }
 
-    public function setHeaderTemplateClassName( string $headerTemplateClassName ): self
+    public function setHeaderTemplateClassName(string $headerTemplateClassName): self
     {
-        if ( class_exists( $headerTemplateClassName ) === false ) {
+        if (class_exists($headerTemplateClassName) === false) {
             throw new InvalidConfigurationException(
                 "Header template class '$headerTemplateClassName' does not exist"
             );
@@ -121,9 +132,9 @@ final class Kernel
         return $this;
     }
 
-    public function setFooterTemplateClassName( string $footerTemplateClassName ): self
+    public function setFooterTemplateClassName(string $footerTemplateClassName): self
     {
-        if ( class_exists( $footerTemplateClassName ) === false ) {
+        if (class_exists($footerTemplateClassName) === false) {
             throw new InvalidConfigurationException(
                 "Footer template class '$footerTemplateClassName' does not exist"
             );
@@ -137,32 +148,33 @@ final class Kernel
 
     private function setDefaultLocale(): void
     {
-        if ( s()->has( 'locale' ) ) {
-            define( 'DEFAULT_LOCALE', s()->get( 'locale' ) );
+        if (s()->has('locale')) {
+            define('DEFAULT_LOCALE', s()->get('locale'));
 
             return;
         }
 
         /** @noinspection GlobalVariableUsageInspection */
-        if ( array_key_exists( 'HTTP_ACCEPT_LANGUAGE', $_SERVER ) === false ) {
-            define( 'DEFAULT_LOCALE', Locale::getLocaleKey( Locale::en ) );
+        if (array_key_exists('HTTP_ACCEPT_LANGUAGE', $_SERVER) === false) {
+            define('DEFAULT_LOCALE', Locale::getLocaleKey(Locale::en));
 
             return;
         }
 
-        $rc = new ReflectionClass( Locale::class );
+        $rc = new ReflectionClass(Locale::class);
         /** @noinspection GlobalVariableUsageInspection */
-        $acceptLanguages = explode( ',', $_SERVER['HTTP_ACCEPT_LANGUAGE'] );
+        $acceptLanguages = explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
 
-        foreach ( $acceptLanguages as $langCode )
-            if ( $rc->hasConstant( $langCode ) && in_array( $langCode, LANGUAGES_LIST, true ) ) {
-                define( 'DEFAULT_LOCALE', Locale::getLocaleKey( $rc->getConstant( $langCode ) ) );
-                s()->set( 'locale', DEFAULT_LOCALE );
+        foreach ($acceptLanguages as $langCode) {
+            if ($rc->hasConstant($langCode) && in_array($langCode, LANGUAGES_LIST, true)) {
+                define('DEFAULT_LOCALE', Locale::getLocaleKey($rc->getConstant($langCode)));
+                s()->set('locale', DEFAULT_LOCALE);
 
                 return;
             }
+        }
 
-        define( 'DEFAULT_LOCALE', LANGUAGES_LIST[0] );
+        define('DEFAULT_LOCALE', LANGUAGES_LIST[0]);
     }
 
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace PHP_SF\System;
 
-use JetBrains\PhpStorm\Deprecated;
 use PHP_SF\System\Classes\Helpers\Locale;
 use PHP_SF\System\Core\TemplatesCache;
+use PHP_SF\System\Core\Translator;
 use PHP_SF\Templates\Layout\footer;
 use PHP_SF\Templates\Layout\header;
 use ReflectionClass;
@@ -23,6 +23,10 @@ final class Kernel
     private static string $applicationUserClassName = '';
     private static string $headerTemplateClassName  = header::class;
     private static string $footerTemplateClassName  = footer::class;
+
+    /** @var string[] */
+    private static array $translationDirs   = [];
+    private static bool  $translationsReady = false;
 
     public function __construct()
     {
@@ -44,6 +48,9 @@ final class Kernel
 
         $this->addTemplatesDirectory('vendor/nations-original/php-simple-framework/templates', 'PHP_SF\Templates');
 
+        // Register the framework's own translation directory automatically.
+        self::$translationDirs[] = __DIR__.'/../translations';
+
         register_shutdown_function(function () {
             rp()->execute();
         });
@@ -60,22 +67,32 @@ final class Kernel
         return $this;
     }
 
-    /** @deprecated No-op. Translation paths are now configured in config/packages/translation.yaml. */
-    #[Deprecated(
-        reason: 'No-op. Translation paths are now configured in config/packages/translation.yaml.',
-        replacement: 'No direct replacement, translation paths should be configured in config/packages/translation.yaml.'
-    )]
+    /**
+     * Registers a directory containing YAML translation files (e.g. {@see translations/messages+intl-icu.en.yaml}).
+     * All registered directories are loaded by {@see bootTranslations()}, which is called automatically
+     * by {@see Router::init()} and {@see Router::loadRoutesOnly()} before any route is dispatched.
+     */
     public function addTranslationFiles(string $path): self
     {
-        trigger_deprecation(
-            'php-simple-framework',
-            '1.1.9',
-            'The method %s is deprecated since version 1.1.9 and will be removed in the next major release. '.
-            'Translation paths are now configured in config/packages/translation.yaml.',
-            __METHOD__
-        );
+        self::$translationDirs[] = $path;
 
         return $this;
+    }
+
+    /**
+     * Boots a lightweight standalone Symfony translator from all registered translation directories.
+     * Idempotent — safe to call multiple times; only the first call has any effect.
+     * Called automatically by {@see Router::init()} and {@see Router::loadRoutesOnly()}.
+     */
+    public function bootTranslations(): void
+    {
+        if (self::$translationsReady) {
+            return;
+        }
+
+        self::$translationsReady = true;
+
+        Translator::bootStandalone(...self::$translationDirs);
     }
 
     public function addTemplatesDirectory(string $templatesDirectoryName, string $namespaceName): self

--- a/src/Router.php
+++ b/src/Router.php
@@ -73,6 +73,8 @@ class Router
         if ( $kernel !== null )
             self::$kernel = $kernel;
 
+        self::$kernel?->bootTranslations();
+
         static::parseRoutes();
     }
 
@@ -83,6 +85,8 @@ class Router
             ?? throw new InvalidConfigurationException(
                 'Kernel must be set before calling Router::init() without passing it as a parameter!'
             );
+
+        self::$kernel->bootTranslations();
 
         $yamlConfigCacheKey = '/config/packages/doctrine.yaml';
 

--- a/src/Traits/ModelProperty/ModelPropertyCreatedAtTrait.php
+++ b/src/Traits/ModelProperty/ModelPropertyCreatedAtTrait.php
@@ -12,7 +12,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 trait ModelPropertyCreatedAtTrait
 {
 
-    #[TranslatablePropertyName('Created At')]
+    #[TranslatablePropertyName('common.fields.created_at')]
     #[ORM\Column(name: 'created_at', type: 'datetime', nullable: false, options: ['default' => new CurrentTimestamp()])]
     #[Groups(['read'])]
     protected string|DateTimeInterface|null $createdAt;

--- a/src/Traits/ModelProperty/ModelPropertyUpdatedAtTrait.php
+++ b/src/Traits/ModelProperty/ModelPropertyUpdatedAtTrait.php
@@ -12,7 +12,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 trait ModelPropertyUpdatedAtTrait
 {
 
-    #[TranslatablePropertyName('Updated At')]
+    #[TranslatablePropertyName('common.fields.updated_at')]
     #[ORM\Column(name: 'updated_at', type: 'datetime', nullable: true, options: ['default' => new CurrentTimestamp()])]
     #[Groups(['read', 'write'])]
     protected string|DateTimeInterface|null $updatedAt = null;

--- a/templates/Auth/login_page.php
+++ b/templates/Auth/login_page.php
@@ -18,8 +18,8 @@ final class login_page extends AbstractView { public function show(): void { ?>
         <tbody>
 
         <tr>
-          <td><?= _t( 'E-mail' ) ?>:</td>
-          <td><?php formInput( 'E-mail', [ 6, 50 ], _t( 'E-mail' ) ) ?></td>
+          <td><?= _t( 'auth.login_form.email_label' ) ?>:</td>
+          <td><?php input( 'E-mail', [ 6, 50 ], _t( 'auth.login_form.email_placeholder' ) ) ?></td>
         </tr>
 
         <tr>
@@ -28,8 +28,8 @@ final class login_page extends AbstractView { public function show(): void { ?>
         </tr>
 
         <tr>
-          <td><input type="submit" value="<?= _t( 'Sign In' ) ?>"></td>
-          <td><a href="<?= routeLink( 'password_recovery' ) ?>">Forgot password?</a></td>
+          <td><input type="submit" value="<?= _t( 'auth.login_form.submit_button' ) ?>"></td>
+          <td><a href="<?= routeLink( 'password_recovery' ) ?>"><?= _t( 'auth.login_form.forgot_password' ) ?></a></td>
         </tr>
 
         </tbody>

--- a/templates/Auth/register_page.php
+++ b/templates/Auth/register_page.php
@@ -22,7 +22,7 @@ final class register_page extends AbstractView { public function show(): void { 
       <div class="line"></div>
 
       <label for="email">
-        <?= _t( 'E-mail' ) ?>: [6-50] <?php formInput( 'email', [ 6, 50 ], 'email' ) ?><br />
+        <?= _t( 'common.fields.email' ) ?>: [6-50] <?php formInput( 'email', [ 6, 50 ], 'email' ) ?><br />
         Enter your email address
       </label>
 

--- a/templates/SettingsPage/change_language_page.php
+++ b/templates/SettingsPage/change_language_page.php
@@ -14,7 +14,7 @@ final class change_language_page extends AbstractView { public function show(): 
 
   <form method="POST">
 
-    <label for="language"> <?= _t( 'Select Language' ) ?> <br /><br />
+    <label for="language"> <?= _t( 'settings.language_form.select_label' ) ?> <br /><br />
       <select name="lang" id="language">
         <?php foreach ( LANGUAGES_LIST as $lang ) : ?>
           <option value="<?= $lang ?>"><?= Locale::getLocaleName( $lang ) ?></option>
@@ -24,7 +24,7 @@ final class change_language_page extends AbstractView { public function show(): 
 
     <br /><br />
 
-    <input type="submit" value="<?= _t( 'Change' ) ?>">
+    <input type="submit" value="<?= _t( 'common.buttons.change' ) ?>">
 
   </form>
 

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -1,0 +1,100 @@
+# Framework translations — English
+# ICU message format: use {param} for placeholders
+
+# ── Auth ──────────────────────────────────────────────────────────────────────
+
+auth.login_form.email_label: 'E-mail'
+auth.login_form.email_placeholder: 'E-mail'
+auth.login_form.submit_button: 'Sign in'
+auth.login_form.forgot_password: 'Forgot password?'
+auth.login_form.empty_credentials_error: 'Email and password cannot be empty.'
+auth.login_form.user_not_found_error: 'User with this email not found.'
+auth.login_form.wrong_password_error: 'Wrong password.'
+
+auth.register_form.password_length_error: 'Password must be between {min} and {max} characters.'
+auth.register_form.accept_terms_error: 'You must accept the terms and conditions.'
+auth.register_form.email_taken_error: 'A user with this email already exists.'
+auth.register_form.login_taken_error: 'A user with this login already exists.'
+
+# ── Settings ──────────────────────────────────────────────────────────────────
+
+settings.language_form.select_label: 'Select Language'
+
+# ── Common — buttons ──────────────────────────────────────────────────────────
+
+common.buttons.change: 'Change'
+
+# ── Common — errors ───────────────────────────────────────────────────────────
+
+common.errors.access_denied: 'Access Denied!'
+common.errors.generic: 'Something went wrong, please try again.'
+
+# ── Common — field labels (used in forms and validation messages) ──────────────
+
+common.fields.email: 'E-mail'
+common.fields.name: 'Name'
+common.fields.password: 'Password'
+common.fields.user_group: 'User Group'
+common.fields.created_at: 'Created At'
+common.fields.updated_at: 'Updated At'
+
+# ── Common — validation ───────────────────────────────────────────────────────
+
+common.validation.field_too_long: 'Field {field} is too long. It should have {max} character or less.'
+common.validation.field_too_short: 'Field {field} is too short. It should have {min} character or more.'
+common.validation.field_null: 'Field {field} cannot be null.'
+common.validation.field_invalid_email: 'Field {field} is not a valid email address.'
+common.validation.field_invalid_numbers: 'Field {field} must be one of these numbers: ({values})'
+common.validation.field_between: 'Field {field} should be between {min} and {max}!'
+
+# ── Common — time ─────────────────────────────────────────────────────────────
+
+common.time.years: >-
+  {count, plural,
+    one   {# yr}
+    few   {# yrs}
+    many  {# yrs}
+    other {# yrs}
+  }
+
+common.time.months: >-
+  {count, plural,
+    one   {# mo}
+    few   {# mos}
+    many  {# mos}
+    other {# mos}
+  }
+
+common.time.days: >-
+  {count, plural,
+    one   {# d}
+    few   {# d}
+    many  {# d}
+    other {# d}
+  }
+
+common.time.hours: >-
+  {count, plural,
+    one   {# hr}
+    few   {# hrs}
+    many  {# hrs}
+    other {# hrs}
+  }
+
+common.time.minutes: >-
+  {count, plural,
+    one   {# min}
+    few   {# min}
+    many  {# min}
+    other {# min}
+  }
+
+common.time.seconds: >-
+  {count, plural,
+    one   {# sec}
+    few   {# sec}
+    many  {# sec}
+    other {# sec}
+  }
+
+common.time.moment_ago: 'a moment ago'


### PR DESCRIPTION
## Description

This pull request introduces a comprehensive overhaul of the translation system, moving from PHP array-based translations to YAML files with ICU MessageFormat support. It standardizes translation key naming, enables advanced features like pluralization and gender selection, and updates all usages to the new system. The changes also include improvements to translation directory management and documentation.

**Translation System Modernization:**

* Replaces the old `_t()` and `_tt()` helper functions with new versions that support named ICU parameters, pluralization, and gender/declension, using YAML translation files and dot-notation keys. Adds detailed PHPDoc and usage examples. (`functions/functions.php`)
* Updates the translation directories to use `translations/` for the app and `Platform/translations/` for the framework, and removes the old `lang/` directory. (`README.md`, `src/Kernel.php`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L195-R201) [[2]](diffhunk://#diff-9f0fabe23af928a9571327c664ebe4f50be0b60646e10e59ed40a30fdadd2532R27-R97)
* Implements a new mechanism in `Kernel` to register multiple translation directories and boot the translator only once, ensuring all translations are loaded before routing. (`src/Kernel.php`, `src/Router.php`) [[1]](diffhunk://#diff-9f0fabe23af928a9571327c664ebe4f50be0b60646e10e59ed40a30fdadd2532R27-R97) [[2]](diffhunk://#diff-95fd90c4e82eb78455558373d51bfb443010152c93eb52b9ff9730cff2a80c96R76-R77) [[3]](diffhunk://#diff-95fd90c4e82eb78455558373d51bfb443010152c93eb52b9ff9730cff2a80c96R89-R90)

**Application-wide Refactoring to Use New Translation Keys:**

* Refactors all usages of `_t()` throughout controllers, middleware, and helpers to use new semantic dot-notation keys and named parameters, replacing hardcoded or old-style keys. (`app/Http/Controller/AuthController.php`, `app/Http/Controller/Defaults/SettingsController.php`, `app/Http/Middleware/api_example.php`, `app/Http/Middleware/cron_example.php`, `src/Classes/Abstracts/Middleware.php`, `functions/time_functions.php`, `src/Traits/ModelProperty/ModelPropertyCreatedAtTrait.php`) [[1]](diffhunk://#diff-fc5409e6341ab90dd80d13bb793e8a115204b82510b68125cf06b3a385dafe55L56-R65) [[2]](diffhunk://#diff-fc5409e6341ab90dd80d13bb793e8a115204b82510b68125cf06b3a385dafe55L100-R112) [[3]](diffhunk://#diff-45012a9c1d00c0e45bdb0a1e431f42ba10e917daef34cbe3123ce57a05decd20L30-R30) [[4]](diffhunk://#diff-09a2175e0364cd07cc48aee3073e73f1f263a2cfe45f73e4691f656eb511ba59L29-R29) [[5]](diffhunk://#diff-63160ddf69290dd616cfb2dbb216917c1184ac6eee25dcada5dd080756871ebbL29-R29) [[6]](diffhunk://#diff-686bbec87d6dc60f538abd2eb531e2496601f441e23412049991ab9ea9ff886cL42-R46) [[7]](diffhunk://#diff-d7ae1d9b94d8048b6847a73b09149b862828f3011e1e77e05f692e3915c9c9e1L38-R57) [[8]](diffhunk://#diff-43618d5232b157864f622b16a3fa6701e64e332e64371961f6317b8afef4b1e9L15-R15)

**Documentation and Clean-up:**

* Updates the README to document the new translation conventions, usage of ICU placeholders, and YAML file locations. (`README.md`)
* Removes the obsolete `lang/en.php` translation file, as translations now use YAML. (`lang/en.php`)

These changes lay the foundation for robust, flexible, and maintainable internationalization throughout the framework and application.

## Type of change

- [ ] Bug fix
- [ ] New feature / improvement
- [x] Refactor
- [ ] Documentation / tooling
- [ ] Dependency update

## Testing

- [x] Existing tests pass (`bin/phpunit`)
- [x] New test added that reproduces the bug / covers the feature (or not applicable — explain below)
