### PR TITLE
TranslatorV2 changes

### DIFF
--- a/src/Core/TranslatorV2.php
+++ b/src/Core/TranslatorV2.php
@@ -287,6 +287,8 @@ final class TranslatorV2 implements TranslatorInterface
             new \RecursiveDirectoryIterator( $entityDir, \RecursiveDirectoryIterator::FOLLOW_SYMLINKS )
         );
 
+        $newEntityKeys = [];
+
         foreach ( $iterator as $file ) {
             if ( !$file->isFile() || $file->getExtension() !== 'php' ) {
                 continue;
@@ -329,12 +331,19 @@ final class TranslatorV2 implements TranslatorInterface
                 foreach ( LANGUAGES_LIST as $locale ) {
                     if ( !array_key_exists( $translationKey, $this->catalogs[$locale] ) ) {
                         $this->catalogs[$locale][$translationKey] = $translationKey . '_not_translated';
+                        $newEntityKeys[]                          = $translationKey;
                     }
                 }
             }
         }
 
-        // Persist any newly added entity keys to the last registered dir
+        if ( empty( $newEntityKeys ) ) {
+            return;
+        }
+
+        $newEntityKeys = array_unique( $newEntityKeys );
+
+        // Persist only the newly discovered entity keys to the last registered dir
         foreach ( LANGUAGES_LIST as $locale ) {
             $lastDir  = self::$dirs[array_key_last( self::$dirs )];
             $filePath = $lastDir . '/' . $locale . '.yaml';
@@ -348,9 +357,9 @@ final class TranslatorV2 implements TranslatorInterface
             }
 
             $added = false;
-            foreach ( $this->catalogs[$locale] as $key => $value ) {
+            foreach ( $newEntityKeys as $key ) {
                 if ( !array_key_exists( $key, $existing ) ) {
-                    $existing[$key] = $value;
+                    $existing[$key] = $key . '_not_translated';
                     $added          = true;
                 }
             }


### PR DESCRIPTION
## Description

This pull request refines how new entity translation keys are handled and persisted in the `TranslatorV2` class. The changes ensure that only newly discovered entity keys are saved, avoiding unnecessary updates and potential duplication.

**Improvements to entity key persistence:**

* Introduced a `$newEntityKeys` array to track translation keys that are newly added during the entity scan, ensuring only these are processed for persistence. [[1]](diffhunk://#diff-bcf18ebd1adf4a44ebbbec8fbf447ee12cdb0c6d9ba932ba1d76e71b88b4620cR290-R291) [[2]](diffhunk://#diff-bcf18ebd1adf4a44ebbbec8fbf447ee12cdb0c6d9ba932ba1d76e71b88b4620cR334-R346)
* Changed the logic to persist only the new entity keys to the YAML files, rather than iterating over all catalog keys, which improves efficiency and prevents overwriting existing translations.
* Added an early return if no new entity keys are found, avoiding unnecessary file operations.
* Ensured that `$newEntityKeys` contains only unique values before persisting, preventing duplicate entries.

## Type of change

- [x] Bug fix
- [ ] New feature / improvement
- [x] Refactor (no behaviour change)
- [ ] Documentation / tooling
- [ ] Dependency update

## Testing

- [x] Existing tests pass (`bin/phpunit`)
