### PR TITLE
feat(build): load vendor.js and app.css from webpack manifest

### DIFF
--- a/templates/Layout/HeaderComponents/head.php
+++ b/templates/Layout/HeaderComponents/head.php
@@ -12,6 +12,8 @@ final class head extends AbstractView { public function show(): void { ?>
   <!DOCTYPE html>
 <html lang="<?= DEFAULT_LOCALE ?>">
   <head>
+    <link rel="stylesheet" href="<?= manifest_asset('app.css') ?>">
+    <script type="text/javascript" src="<?= manifest_asset('vendor.js') ?>"></script>
     <script type="text/javascript" src="<?= manifest_asset('app.js') ?>"></script>
     <script type="text/javascript" src="<?= asset('js/jquery-3.6.0.min.js') ?>"></script>
     <script type="text/javascript" src="<?= asset('js/bootstrap.min.js') ?>"></script>


### PR DESCRIPTION
## Description

This pull request updates the HTML head section to include the main CSS and vendor JavaScript assets generated by the build system. This ensures that the application loads the latest compiled styles and vendor scripts.

**Asset inclusion updates:**

* Added a link to the compiled stylesheet `app.css` using `manifest_asset`, ensuring the latest styles are loaded.
* Added a script tag for the compiled vendor JavaScript bundle `vendor.js` using `manifest_asset`, allowing third-party libraries to be loaded efficiently.

## Type of change

- [ ] Bug fix
- [x] New feature / improvement
- [ ] Refactor (no behaviour change)
- [ ] Documentation / tooling
- [ ] Dependency update

## Testing

- [x] Existing tests pass (`bin/phpunit`)
