### PR TITLE
fix(TemplatesCache): avoid CRLF injection inside string interpolations

### DIFF
--- a/src/Core/TemplatesCache.php
+++ b/src/Core/TemplatesCache.php
@@ -329,16 +329,19 @@ final class TemplatesCache
         $w = [ ';', '{', '}' ];
         $ts = token_get_all( php_strip_whitespace( $filename ) );
         $s = '';
+        $interpDepth = 0;
 
         foreach ( $ts as $t ) {
-            if ( is_array( $t ) )
+            if ( is_array( $t ) ) {
+                if ( $t[0] === T_CURLY_OPEN || $t[0] === T_DOLLAR_OPEN_CURLY_BRACES )
+                    $interpDepth++;
                 $s .= $t[1];
-
-            else {
+            } else {
                 $s .= $t;
-                if ( in_array( $t, $w, true ) )
+                if ( $t === '}' && $interpDepth > 0 )
+                    $interpDepth--;
+                elseif ( in_array( $t, $w, true ) )
                     $s .= chr( 13 ) . chr( 10 );
-
             }
         }
 


### PR DESCRIPTION
removeComments() appended \r\n after every non-array '}' token. This also matched closing braces in "{$var}" / "${var}" inside double-quoted strings, corrupting values (e.g. data-bs-theme="dark" → "dark\r\n").

Track interpolation depth via T_CURLY_OPEN / T_DOLLAR_OPEN_CURLY_BRACES and only append CRLF when '}' closes an actual code block (depth === 0).

## Description

<!-- What does this PR do? Why? Link to related issue if applicable: Fixes #... -->

## Type of change

- [x] Bug fix
- [ ] New feature / improvement
- [ ] Refactor (no behaviour change)
- [ ] Documentation / tooling
- [ ] Dependency update