### PR TITLE
Fixes two silent runtime errors in `Router`

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -420,9 +420,16 @@ class Router
          */
         $httpMethod = $_SERVER['REQUEST_METHOD'];
 
-        if ( array_key_exists( $httpMethod, self::$routesByUrl ) === false )
-            throw new RuntimeException( 'Looks like something went wrong with parsing routes from controllers.' .
-                                        ' Routes list for current httpMethod is empty. Please, check your controllers and routes!' );
+        // HEAD shares GET routes per HTTP spec
+        if ( $httpMethod === 'HEAD' && !array_key_exists( 'HEAD', self::$routesByUrl ) ) {
+            $httpMethod = 'GET';
+        }
+
+        if ( array_key_exists( $httpMethod, self::$routesByUrl ) === false ) {
+            header( 'Allow: ' . implode( ', ', array_keys( self::$routesByUrl ) ) );
+            http_response_code( 405 );
+            exit;
+        }
 
         $currentUrl = static::getCurrentRequestUrl();
         $urlHash = hash( 'sha256', $currentUrl );
@@ -766,10 +773,11 @@ class Router
                 ob_end_clean();
                 throw new ViewException( $e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine(), $e );
             }
-        }
+        } else // if ( $response instanceof JsonResponse or RedirectResponse or plain SymfonyResponse
+            $response->send();
 
-        // if ( $response instanceof JsonResponse )
-        $response->send();
+        /** @noinspection PhpUnreachableStatementInspection */
+        exit;
     }
 
     #[NoReturn]


### PR DESCRIPTION
## Description

1. **`sendRouteMethodResponse()` implicit return** — method is declared `never` but could
     implicitly return when `$response` is a PHP-SF `Response` instance, causing a PHP engine
     `TypeError`. Fixed by restructuring the send branches into `if/else` and adding a
     guaranteed `exit` at the end.

  2. **`setCurrentRoute()` throws on unregistered HTTP methods** — any request using a method
     not present in `$routesByUrl` (e.g. `OPTIONS`, `TRACE`) caused an unhandled
     `RuntimeException`. Fixed with two behaviours aligned to HTTP spec:
     - `HEAD` falls back to `GET` routes (RFC 9110 §9.3.2)
     - All other unregistered methods return `405 Method Not Allowed` with an `Allow` header
       listing registered methods, then exit cleanly

## Type of change

- [x] Bug fix

## Testing

- [ ] Existing tests pass (`bin/phpunit`)
- [x] New test added that reproduces the bug / covers the feature (or not applicable — explain below)

Not applicable — both code paths are framework-internal and triggered by specific HTTP
  conditions (`never`-return and unregistered methods). Covered by manual verification;
  no unit test infrastructure exists for these Router internals currently.

## Checklist

- [x] `declare(strict_types=1)` in every new PHP file
- [x] No `@author` tags, no unnecessary docblocks added
- [x] No license headers in individual files
- [ ] All commits signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
