### PR TITLE
Add CSP nonce support to RedirectResponse

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "nations-original/php-simple-framework",
-  "version": "2.0.0",
   "description": "A simple PHP framework for Nations Original.",
   "authors": [
     {

--- a/src/Core/RedirectResponse.php
+++ b/src/Core/RedirectResponse.php
@@ -91,10 +91,13 @@ final class RedirectResponse extends Response
         if ( empty( $_GET ) === false ) {
             $replacedUrl .= '?' . http_build_query( $_GET );
         }
-        $nonceAttr = self::$cspNonce !== null ? ' nonce="' . self::$cspNonce . '"' : '' ?>
+        $nonceAttr = self::$cspNonce !== null
+            ? ' nonce="' . htmlspecialchars( self::$cspNonce, ENT_QUOTES, 'UTF-8' ) . '"'
+            : '';
+        $safeUrl = json_encode( $replacedUrl, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT ); ?>
 
         <script<?= $nonceAttr ?>>
-            history.replaceState( {}, '', '<?= $replacedUrl ?>' );
+            history.replaceState( {}, '', <?= $safeUrl ?> );
         </script>
 
         <?php

--- a/src/Core/RedirectResponse.php
+++ b/src/Core/RedirectResponse.php
@@ -30,6 +30,19 @@ final class RedirectResponse extends Response
         self::ALERT_INFO,
     ];
 
+    private static ?string $cspNonce = null;
+
+
+    public static function setCspNonce( string $nonce ): void
+    {
+        self::$cspNonce = $nonce;
+    }
+
+    public static function getCspNonce(): ?string
+    {
+        return self::$cspNonce;
+    }
+
 
     public function __construct(
         #[Immutable] private readonly string $targetUrl,
@@ -75,10 +88,12 @@ final class RedirectResponse extends Response
 
 
         $replacedUrl = $this->getTargetUrl();
-        if ( empty( $_GET ) === false )
-            $replacedUrl .= '?' . http_build_query( $_GET ) ?>
+        if ( empty( $_GET ) === false ) {
+            $replacedUrl .= '?' . http_build_query( $_GET );
+        }
+        $nonceAttr = self::$cspNonce !== null ? ' nonce="' . self::$cspNonce . '"' : '' ?>
 
-        <script>
+        <script<?= $nonceAttr ?>>
             history.replaceState( {}, '', '<?= $replacedUrl ?>' );
         </script>
 


### PR DESCRIPTION
## Description

This pull request introduces a mechanism to support Content Security Policy (CSP) nonces in the `RedirectResponse` class, improving security for inline scripts. It adds static methods to set and retrieve a CSP nonce, and updates the redirect logic to include the nonce in the `<script>` tag if set.

**Security enhancements:**

* Added static property and methods (`setCspNonce`, `getCspNonce`) in `RedirectResponse` to manage a CSP nonce for use in inline scripts.
* Modified the redirect script output to conditionally include the `nonce` attribute in the `<script>` tag based on the set CSP nonce.

**Other:**

* Removed the `version` field from `composer.json`.

## Type of change

- [ ] Bug fix
- [x] New feature / improvement
- [ ] Refactor (no behaviour change)
- [ ] Documentation / tooling
- [ ] Dependency update

## Testing

- [x] Existing tests pass (`bin/phpunit`)

## Checklist

- [x] No `@author` tags, no unnecessary docblocks added
- [x] No license headers in individual files
